### PR TITLE
Rename Text to Typography

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ yarn test
 ├── dist
 │   └── index.js: ES module bundle for publishing to npm
 ├── src: Components organized into atoms, molecules, and organisms (see Atomic Design)
-│   ├── atoms: Cannot implement any other components (with <Text /> as an exception); Mainly acts as a styling wrapper for basic HTML elements
+│   ├── atoms: Cannot implement any other components (with <Typography /> as an exception); Mainly acts as a styling wrapper for basic HTML elements
 │   │   ├── Button
 │   │   │   ├── Button.tsx: React component
 │   │   │   ├── Button.story.tsx: Storybook story

--- a/src/Theme.story.tsx
+++ b/src/Theme.story.tsx
@@ -2,7 +2,7 @@ import { storiesOf } from '@storybook/react';
 import { margin, size } from 'polished';
 import React, { DetailedHTMLProps, HTMLAttributes } from 'react';
 import { StyledComponentClass, withTheme } from 'styled-components';
-import Text from '../src/atoms/Text';
+import Typography from '../src/atoms/Typography';
 import styled from './styled-components';
 import Theme from './Theme';
 
@@ -14,7 +14,7 @@ const Color = styled.div`
   border-radius: 50%; /* stylelint-disable-line unit-whitelist */
 `;
 
-const Code = styled(Text)`
+const Code = styled(Typography)`
   font-family: monospace;
 ` as StyledComponentClass<
   DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>,

--- a/src/atoms/Button/Button.tsx
+++ b/src/atoms/Button/Button.tsx
@@ -3,13 +3,13 @@ import { ButtonHTMLAttributes, DetailedHTMLProps } from 'react';
 import { StyledComponentClass } from 'styled-components';
 import styled from '../../styled-components';
 import Theme, { borderRadius, scale, transitionDuration } from '../../Theme';
-import Text from '../Text';
+import Typography from '../Typography';
 
 interface Props {
   large?: boolean;
 }
 
-export const Button = styled(Text)<Props>`
+export const Button = styled(Typography)<Props>`
   background: ${props => props.theme.primary};
   border: none;
   border-radius: ${borderRadius};

--- a/src/atoms/Heading/Heading.tsx
+++ b/src/atoms/Heading/Heading.tsx
@@ -2,9 +2,9 @@ import { DetailedHTMLProps, HTMLAttributes } from 'react';
 import { StyledComponentClass } from 'styled-components';
 import styled from '../../styled-components';
 import Theme, { scale } from '../../Theme';
-import Text from '../Text';
+import Typography from '../Typography';
 
-export const Heading = styled(Text)`
+export const Heading = styled(Typography)`
   color: ${(props: any) => props.as === 'h1' && props.theme.headline};
   font-size: ${(props: any) => scale(props.as === 'h1' ? 2 : 1)};
 ` as StyledComponentClass<

--- a/src/atoms/Icon/Icon.story.tsx
+++ b/src/atoms/Icon/Icon.story.tsx
@@ -1,17 +1,17 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import Icon, { IconName, icons } from '.';
-import Text from '../Text';
+import Typography from '../Typography';
 
 storiesOf('Atoms', module).add('Icon', () =>
   icons.map(({ iconName }) => (
-    <Text key={iconName} as="span">
+    <Typography key={iconName} as="span">
       <Icon
         key={iconName}
         icon={iconName as IconName}
         title={iconName}
         size="3x"
       />
-    </Text>
+    </Typography>
   )),
 );

--- a/src/atoms/Input/Input.story.tsx
+++ b/src/atoms/Input/Input.story.tsx
@@ -1,12 +1,12 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import Input from '.';
-import Text from '../Text';
+import Typography from '../Typography';
 
 storiesOf('Atoms', module).add('Input', () => (
-  <Text as="label">
+  <Typography as="label">
     To Address
     <br />
     <Input placeholder="0x4bbeEB066eD09B7AEd07bF39EEe0460DFa261520" />
-  </Text>
+  </Typography>
 ));

--- a/src/atoms/Input/Input.tsx
+++ b/src/atoms/Input/Input.tsx
@@ -3,9 +3,9 @@ import { DetailedHTMLProps, InputHTMLAttributes } from 'react';
 import { StyledComponentClass } from 'styled-components';
 import styled from '../../styled-components';
 import Theme, { borderRadius, scale, transitionDuration } from '../../Theme';
-import Text from '../Text';
+import Typography from '../Typography';
 
-export const Input = styled(Text)`
+export const Input = styled(Typography)`
   background: ${props => props.theme.controlBackground};
   border: 0.125em solid ${props => props.theme.controlBorder};
   border-radius: ${borderRadius};

--- a/src/atoms/Panel/Panel.story.tsx
+++ b/src/atoms/Panel/Panel.story.tsx
@@ -3,16 +3,18 @@ import faker from 'faker';
 import React from 'react';
 import Panel from '.';
 import styled from '../../styled-components';
-import Text from '../Text';
+import Typography from '../Typography';
 
-const TextWithoutMargin = styled(Text)`
+const TypographyWithoutMargin = styled(Typography)`
   margin: 0;
 `;
 
 storiesOf('Atoms', module).add('Panel', () =>
   [{}, { basic: true }, { noPadding: true }].map((props, index) => (
     <Panel key={index} {...props}>
-      <TextWithoutMargin>{faker.lorem.paragraphs()}</TextWithoutMargin>
+      <TypographyWithoutMargin>
+        {faker.lorem.paragraphs()}
+      </TypographyWithoutMargin>
     </Panel>
   )),
 );

--- a/src/atoms/Text/Text.story.tsx
+++ b/src/atoms/Text/Text.story.tsx
@@ -1,8 +1,0 @@
-import { storiesOf } from '@storybook/react';
-import faker from 'faker';
-import React from 'react';
-import Text from '.';
-
-storiesOf('Atoms', module).add('Text', () => (
-  <Text>{faker.lorem.paragraphs()}</Text>
-));

--- a/src/atoms/Text/Text.test.tsx
+++ b/src/atoms/Text/Text.test.tsx
@@ -1,9 +1,0 @@
-import 'jest-dom/extend-expect';
-import React from 'react';
-import { render } from 'react-testing-library';
-import Text from '.';
-
-test('Text', () => {
-  const { getByText } = render(<Text>Text</Text>);
-  expect(getByText('Text')).toHaveTextContent('Text');
-});

--- a/src/atoms/Text/index.tsx
+++ b/src/atoms/Text/index.tsx
@@ -1,1 +1,0 @@
-export { default } from './Text';

--- a/src/atoms/Typography/Typography.story.tsx
+++ b/src/atoms/Typography/Typography.story.tsx
@@ -1,0 +1,8 @@
+import { storiesOf } from '@storybook/react';
+import faker from 'faker';
+import React from 'react';
+import Typography from '.';
+
+storiesOf('Atoms', module).add('Typography', () => (
+  <Typography>{faker.lorem.paragraphs()}</Typography>
+));

--- a/src/atoms/Typography/Typography.test.tsx
+++ b/src/atoms/Typography/Typography.test.tsx
@@ -1,0 +1,9 @@
+import 'jest-dom/extend-expect';
+import React from 'react';
+import { render } from 'react-testing-library';
+import Typography from '.';
+
+test('Typography', () => {
+  const { getByText } = render(<Typography>Typography</Typography>);
+  expect(getByText('Typography')).toHaveTextContent('Typography');
+});

--- a/src/atoms/Typography/Typography.tsx
+++ b/src/atoms/Typography/Typography.tsx
@@ -1,10 +1,10 @@
 import 'typeface-lato';
 import styled from '../../styled-components';
 
-export const Text = styled.p`
+export const Typography = styled.p`
   color: ${props => props.theme.text};
   font-family: Lato, sans-serif;
   line-height: 1.5;
 `;
 
-export default Text;
+export default Typography;

--- a/src/atoms/Typography/index.tsx
+++ b/src/atoms/Typography/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Typography';

--- a/src/atoms/index.ts
+++ b/src/atoms/index.ts
@@ -3,4 +3,4 @@ export { default as Heading } from './Heading';
 export { default as Icon } from './Icon';
 export { default as Input } from './Input';
 export { default as Panel } from './Panel';
-export { default as Text } from './Text';
+export { default as Typography } from './Typography';

--- a/src/molecules/ActionPanel/ActionPanel.story.tsx
+++ b/src/molecules/ActionPanel/ActionPanel.story.tsx
@@ -2,7 +2,7 @@ import { storiesOf } from '@storybook/react';
 import faker from 'faker';
 import React from 'react';
 import ActionPanel from '.';
-import Text from '../../atoms/Text';
+import Typography from '../../atoms/Typography';
 
 storiesOf('Molecules', module).add('ActionPanel', () =>
   [{}, { noPadding: true }].map((props, index) => (
@@ -12,7 +12,7 @@ storiesOf('Molecules', module).add('ActionPanel', () =>
       href="https://example.com/"
       {...props}
     >
-      <Text>{faker.lorem.paragraphs()}</Text>
+      <Typography>{faker.lorem.paragraphs()}</Typography>
     </ActionPanel>
   )),
 );

--- a/src/molecules/ActionPanel/ActionPanel.tsx
+++ b/src/molecules/ActionPanel/ActionPanel.tsx
@@ -6,7 +6,7 @@ import React, {
 } from 'react';
 import { StyledComponentClass } from 'styled-components';
 import Panel from '../../atoms/Panel';
-import Text from '../../atoms/Text';
+import Typography from '../../atoms/Typography';
 import styled from '../../styled-components';
 import Theme, { scale } from '../../Theme';
 
@@ -14,7 +14,7 @@ const ActionPanelBody = styled.div`
   ${padding(scale(1), scale(2))};
 `;
 
-const ActionPanelLink = styled(Text)`
+const ActionPanelLink = styled(Typography)`
   background: ${props => props.theme.actionPanelBackground};
   border-top: 0.0416em solid ${props => props.theme.actionPanelBorder};
   color: ${props => props.theme.link};

--- a/src/molecules/List/List.tsx
+++ b/src/molecules/List/List.tsx
@@ -1,11 +1,11 @@
 import { directionalProperty, padding } from 'polished';
 import React, { Children, ReactNode } from 'react';
 import Panel from '../../atoms/Panel';
-import Text from '../../atoms/Text';
+import Typography from '../../atoms/Typography';
 import styled from '../../styled-components';
 import { scale } from '../../Theme';
 
-const GroupItem = styled(Text)`
+const GroupItem = styled(Typography)`
   ${props =>
     directionalProperty(
       'border',
@@ -23,7 +23,7 @@ const GroupItem = styled(Text)`
   }
 `;
 
-const ListItem = styled(Text)`
+const ListItem = styled(Typography)`
   list-style-position: inside;
 `;
 

--- a/src/organisms/ComboBox/ComboBox.story.tsx
+++ b/src/organisms/ComboBox/ComboBox.story.tsx
@@ -1,12 +1,12 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import ComboBox from '.';
-import Text from '../../atoms/Text';
+import Typography from '../../atoms/Typography';
 
 storiesOf('Organisms', module).add('ComboBox', () => (
-  <Text as="label">
+  <Typography as="label">
     Enter a fruit
     <br />
     <ComboBox items={new Set(['apple', 'pear', 'orange', 'grape', 'banana'])} />
-  </Text>
+  </Typography>
 ));


### PR DESCRIPTION
Text clashes with TypeScript's type for Text in the DOM APIs, and it keeps screwing up automatic imports in the UI source code.