### PR TITLE
UI-99 IconLink

### DIFF
--- a/src/molecules/IconLink/IconLink.story.tsx
+++ b/src/molecules/IconLink/IconLink.story.tsx
@@ -2,8 +2,10 @@ import { storiesOf } from '@storybook/react';
 import React from 'react';
 import IconLink from '.';
 
-storiesOf('Molecules', module).add('IconLink', () => (
-  <React.Fragment>
-    Address <IconLink href="https://example.com/" icon="shield-alt" />
-  </React.Fragment>
-));
+storiesOf('Molecules', module).add('IconLink', () =>
+  [{}, { href: 'https://example.com/' }].map((props, index) => (
+    <React.Fragment key={index}>
+      Address <IconLink {...props} icon="shield-alt" />
+    </React.Fragment>
+  )),
+);

--- a/src/molecules/IconLink/IconLink.story.tsx
+++ b/src/molecules/IconLink/IconLink.story.tsx
@@ -3,7 +3,10 @@ import React from 'react';
 import IconLink from '.';
 
 storiesOf('Molecules', module).add('IconLink', () =>
-  [{}, { href: 'https://example.com/' }].map((props, index) => (
+  [
+    { ariaLabel: 'shield-icon' },
+    { href: 'https://example.com/', ariaLabel: 'shield-icon' },
+  ].map((props, index) => (
     <React.Fragment key={index}>
       Address <IconLink {...props} icon="shield-alt" />
     </React.Fragment>

--- a/src/molecules/IconLink/IconLink.story.tsx
+++ b/src/molecules/IconLink/IconLink.story.tsx
@@ -1,0 +1,9 @@
+import { storiesOf } from '@storybook/react';
+import React from 'react';
+import IconLink from '.';
+
+storiesOf('Molecules', module).add('IconLink', () => (
+  <React.Fragment>
+    Address <IconLink href="https://example.com/" icon="shield-alt" />
+  </React.Fragment>
+));

--- a/src/molecules/IconLink/IconLink.story.tsx
+++ b/src/molecules/IconLink/IconLink.story.tsx
@@ -4,8 +4,8 @@ import IconLink from '.';
 
 storiesOf('Molecules', module).add('IconLink', () =>
   [
-    { ariaLabel: 'shield-icon' },
-    { href: 'https://example.com/', ariaLabel: 'shield-icon' },
+    { 'aria-label': 'shield-icon' },
+    { href: 'https://example.com/', 'aria-label': 'shield-icon' },
   ].map((props, index) => (
     <React.Fragment key={index}>
       Address <IconLink {...props} icon="shield-alt" />

--- a/src/molecules/IconLink/IconLink.test.tsx
+++ b/src/molecules/IconLink/IconLink.test.tsx
@@ -9,7 +9,7 @@ test('IconLink', () => {
     <IconLink
       href="https://example.com/"
       icon="shield-alt"
-      ariaLabel="shield-button"
+      aria-label="shield-button"
     />,
   );
   const iconLink = getByLabelText('shield-button');
@@ -18,7 +18,7 @@ test('IconLink', () => {
   rerender(
     <IconLink
       icon="shield-alt"
-      ariaLabel="shield-button"
+      aria-label="shield-button"
       handleClick={handleClick}
     />,
   );

--- a/src/molecules/IconLink/IconLink.test.tsx
+++ b/src/molecules/IconLink/IconLink.test.tsx
@@ -1,0 +1,29 @@
+import 'jest-dom/extend-expect';
+import React from 'react';
+import { fireEvent, render } from 'react-testing-library';
+import IconLink from '.';
+
+test('IconLink', () => {
+  const handleClick = jest.fn();
+  const { getByLabelText, rerender } = render(
+    <IconLink
+      href="https://example.com/"
+      icon="shield-alt"
+      ariaLabel="shield-button"
+    />,
+  );
+  const iconLink = getByLabelText('shield-button');
+  expect(iconLink).toHaveAttribute('href', 'https://example.com/');
+
+  rerender(
+    <IconLink
+      icon="shield-alt"
+      ariaLabel="shield-button"
+      handleClick={handleClick}
+    />,
+  );
+  const iconButton = getByLabelText('shield-button');
+  expect(iconButton).toHaveAttribute('type', 'button');
+  fireEvent.click(iconButton);
+  expect(handleClick).toHaveBeenCalled();
+});

--- a/src/molecules/IconLink/IconLink.tsx
+++ b/src/molecules/IconLink/IconLink.tsx
@@ -10,6 +10,7 @@ export const IconTypography = styled(Typography)`
   border: none;
   padding: 0;
   color: ${props => props.theme.text};
+  cursor: pointer;
 
   :hover {
     color: ${props => props.theme.primaryDark};

--- a/src/molecules/IconLink/IconLink.tsx
+++ b/src/molecules/IconLink/IconLink.tsx
@@ -1,0 +1,42 @@
+import React, { ButtonHTMLAttributes, DetailedHTMLProps } from 'react';
+import { StyledComponentClass } from 'styled-components';
+import Icon, { IconName } from '../../atoms/Icon';
+import Typography from '../../atoms/Typography';
+import styled from '../../styled-components';
+import Theme from '../../Theme';
+// import { IconName } from '@fortawesome/fontawesome-svg-core';
+
+IconLink.defaultProps = { as: 'a' };
+
+export const IconTypography = styled(Typography)`
+  background: none;
+  border: none;
+  padding: 0;
+
+  a {
+    color: ${props => props.theme.text};
+  }
+  :hover {
+    /* stylelint-disable-next-line max-nesting-depth */
+    a {
+      color: ${props => props.theme.primaryDark};
+    }
+  }
+` as StyledComponentClass<
+  DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,
+  Theme
+>;
+
+export function IconLink({ href, icon }: { href: string; icon: IconName }) {
+  return (
+    <IconTypography>
+      <a href={href}>
+        <Icon icon={icon} />
+      </a>
+    </IconTypography>
+  );
+}
+
+IconTypography.defaultProps = { as: 'button', type: 'button' };
+
+export default IconLink;

--- a/src/molecules/IconLink/IconLink.tsx
+++ b/src/molecules/IconLink/IconLink.tsx
@@ -12,27 +12,37 @@ export const IconTypography = styled(Typography)`
   background: none;
   border: none;
   padding: 0;
+  color: ${props => props.theme.text};
 
-  a {
-    color: ${props => props.theme.text};
-  }
   :hover {
+    color: ${props => props.theme.primaryDark};
     /* stylelint-disable-next-line max-nesting-depth */
-    a {
-      color: ${props => props.theme.primaryDark};
-    }
   }
 ` as StyledComponentClass<
   DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,
   Theme
 >;
 
-export function IconLink({ href, icon }: { href: string; icon: IconName }) {
-  return (
-    <IconTypography>
-      <a href={href}>
+export function IconLink({
+  href,
+  target,
+  icon,
+  handleClick,
+}: {
+  href?: string;
+  target?: string;
+  icon: IconName;
+  handleClick?(): void;
+}) {
+  return href ? (
+    <a href={href} target={target}>
+      <IconTypography onClick={handleClick}>
         <Icon icon={icon} />
-      </a>
+      </IconTypography>
+    </a>
+  ) : (
+    <IconTypography onClick={handleClick}>
+      <Icon icon={icon} />
     </IconTypography>
   );
 }

--- a/src/molecules/IconLink/IconLink.tsx
+++ b/src/molecules/IconLink/IconLink.tsx
@@ -27,21 +27,23 @@ export function IconLink({
   href,
   target,
   icon,
+  ariaLabel,
   handleClick,
 }: {
   href?: string;
   target?: string;
   icon: IconName;
+  ariaLabel: string;
   handleClick?(): void;
 }) {
   return href ? (
-    <a href={href} target={target}>
+    <a href={href} target={target} aria-label={ariaLabel}>
       <IconTypography onClick={handleClick}>
         <Icon icon={icon} />
       </IconTypography>
     </a>
   ) : (
-    <IconTypography onClick={handleClick}>
+    <IconTypography onClick={handleClick} aria-label={ariaLabel}>
       <Icon icon={icon} />
     </IconTypography>
   );

--- a/src/molecules/IconLink/IconLink.tsx
+++ b/src/molecules/IconLink/IconLink.tsx
@@ -4,9 +4,6 @@ import Icon, { IconName } from '../../atoms/Icon';
 import Typography from '../../atoms/Typography';
 import styled from '../../styled-components';
 import Theme from '../../Theme';
-// import { IconName } from '@fortawesome/fontawesome-svg-core';
-
-IconLink.defaultProps = { as: 'a' };
 
 export const IconTypography = styled(Typography)`
   background: none;
@@ -16,24 +13,25 @@ export const IconTypography = styled(Typography)`
 
   :hover {
     color: ${props => props.theme.primaryDark};
-    /* stylelint-disable-next-line max-nesting-depth */
   }
 ` as StyledComponentClass<
   DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,
   Theme
 >;
 
+IconTypography.defaultProps = { as: 'button', type: 'button' };
+
 export function IconLink({
   href,
   target,
   icon,
-  ariaLabel,
+  'aria-label': ariaLabel,
   handleClick,
 }: {
   href?: string;
   target?: string;
   icon: IconName;
-  ariaLabel: string;
+  'aria-label': string;
   handleClick?(): void;
 }) {
   return href ? (
@@ -48,7 +46,5 @@ export function IconLink({
     </IconTypography>
   );
 }
-
-IconTypography.defaultProps = { as: 'button', type: 'button' };
 
 export default IconLink;

--- a/src/molecules/IconLink/index.ts
+++ b/src/molecules/IconLink/index.ts
@@ -1,0 +1,1 @@
+export { default } from './IconLink';


### PR DESCRIPTION
Closes UI-99

Adds the `IconLink` component which displays an icon that is optionally contained within a link if an `href` is passed as a prop. If no `href` is passed, it will render as just a button which can be placed within another link component (ex: routers) or standalone with `onClick` functionality.

![image](https://user-images.githubusercontent.com/434238/48582308-2c6ef900-e8f2-11e8-9250-8975809d83f3.png)
