### PR TITLE
Add Textarea component

### DIFF
--- a/src/atoms/Textarea/Textarea.story.tsx
+++ b/src/atoms/Textarea/Textarea.story.tsx
@@ -1,0 +1,12 @@
+import { storiesOf } from '@storybook/react';
+import React from 'react';
+import Textarea from '.';
+import Typography from '../Typography';
+
+storiesOf('Atoms', module).add('Textarea', () => (
+  <Typography as="label">
+    To Address
+    <br />
+    <Textarea placeholder="0x4bbeEB066eD09B7AEd07bF39EEe0460DFa261520" />
+  </Typography>
+));

--- a/src/atoms/Textarea/Textarea.test.tsx
+++ b/src/atoms/Textarea/Textarea.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from 'react-testing-library';
+import Textarea from '.';
+
+test('Textarea', () => {
+  render(<Textarea />);
+});

--- a/src/atoms/Textarea/Textarea.tsx
+++ b/src/atoms/Textarea/Textarea.tsx
@@ -1,24 +1,9 @@
-import { padding } from 'polished';
 import { DetailedHTMLProps, TextareaHTMLAttributes } from 'react';
 import { StyledComponentClass } from 'styled-components';
-import styled from '../../styled-components';
-import Theme, { borderRadius, scale, transitionDuration } from '../../Theme';
-import Typography from '../Typography';
+import Theme from '../../Theme';
+import Input from '../Input';
 
-export const Textarea = styled(Typography)`
-  background: ${props => props.theme.controlBackground};
-  border: 0.125em solid ${props => props.theme.controlBorder};
-  border-radius: ${borderRadius};
-  font-size: ${scale(0)};
-  font-weight: bold;
-  ${padding(scale(-1), scale(0))};
-  transition: border ${transitionDuration};
-
-  :focus {
-    border-color: ${props => props.theme.primary};
-    outline: none;
-  }
-` as StyledComponentClass<
+export const Textarea = Input as StyledComponentClass<
   DetailedHTMLProps<
     TextareaHTMLAttributes<HTMLTextAreaElement>,
     HTMLTextAreaElement

--- a/src/atoms/Textarea/Textarea.tsx
+++ b/src/atoms/Textarea/Textarea.tsx
@@ -1,0 +1,28 @@
+import { padding } from 'polished';
+import { DetailedHTMLProps, InputHTMLAttributes } from 'react';
+import { StyledComponentClass } from 'styled-components';
+import styled from '../../styled-components';
+import Theme, { borderRadius, scale, transitionDuration } from '../../Theme';
+import Typography from '../Typography';
+
+export const Textarea = styled(Typography)`
+  background: ${props => props.theme.controlBackground};
+  border: 0.125em solid ${props => props.theme.controlBorder};
+  border-radius: ${borderRadius};
+  font-size: ${scale(0)};
+  font-weight: bold;
+  ${padding(scale(-1), scale(0))};
+  transition: border ${transitionDuration};
+
+  :focus {
+    border-color: ${props => props.theme.primary};
+    outline: none;
+  }
+` as StyledComponentClass<
+  DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>,
+  Theme
+>;
+
+Textarea.defaultProps = { as: 'textarea' };
+
+export default Textarea;

--- a/src/atoms/Textarea/Textarea.tsx
+++ b/src/atoms/Textarea/Textarea.tsx
@@ -1,5 +1,5 @@
 import { padding } from 'polished';
-import { DetailedHTMLProps, InputHTMLAttributes } from 'react';
+import { DetailedHTMLProps, TextareaHTMLAttributes } from 'react';
 import { StyledComponentClass } from 'styled-components';
 import styled from '../../styled-components';
 import Theme, { borderRadius, scale, transitionDuration } from '../../Theme';
@@ -19,7 +19,10 @@ export const Textarea = styled(Typography)`
     outline: none;
   }
 ` as StyledComponentClass<
-  DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>,
+  DetailedHTMLProps<
+    TextareaHTMLAttributes<HTMLTextAreaElement>,
+    HTMLTextAreaElement
+  >,
   Theme
 >;
 

--- a/src/atoms/Textarea/Textarea.tsx
+++ b/src/atoms/Textarea/Textarea.tsx
@@ -1,9 +1,11 @@
+/* stylelint-disable block-no-empty */
 import { DetailedHTMLProps, TextareaHTMLAttributes } from 'react';
 import { StyledComponentClass } from 'styled-components';
+import styled from '../../styled-components';
 import Theme from '../../Theme';
 import Input from '../Input';
 
-export const Textarea = Input as StyledComponentClass<
+export const Textarea = styled(Input)`` as StyledComponentClass<
   DetailedHTMLProps<
     TextareaHTMLAttributes<HTMLTextAreaElement>,
     HTMLTextAreaElement

--- a/src/atoms/Textarea/index.ts
+++ b/src/atoms/Textarea/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Textarea';


### PR DESCRIPTION
Closes UI-90

Adds a `<Textarea />` component for text area fields.

![image](https://user-images.githubusercontent.com/434238/48646182-188ccb00-e9b6-11e8-992e-5a7803f7982e.png)
![image](https://user-images.githubusercontent.com/434238/48646198-293d4100-e9b6-11e8-861c-c0523abd4f35.png)
