### PR TITLE
UI-159 Icon Prop on Inputs

### DIFF
--- a/src/atoms/Input/Input.story.tsx
+++ b/src/atoms/Input/Input.story.tsx
@@ -32,7 +32,7 @@ storiesOf('Atoms', module).add('Input', () =>
       <Input
         icon="copy"
         placeholder="0x4bbeEB066eD09B7AEd07bF39EEe0460DFa261520"
-        iconSide="right"
+        iconSide="left"
       />
     ),
     Network: <ControlledInput validator={validator} />,

--- a/src/atoms/Input/Input.story.tsx
+++ b/src/atoms/Input/Input.story.tsx
@@ -32,6 +32,7 @@ storiesOf('Atoms', module).add('Input', () =>
       <Input
         icon="copy"
         placeholder="0x4bbeEB066eD09B7AEd07bF39EEe0460DFa261520"
+        iconSide="right"
       />
     ),
     Network: <ControlledInput validator={validator} />,

--- a/src/atoms/Input/Input.story.tsx
+++ b/src/atoms/Input/Input.story.tsx
@@ -29,7 +29,10 @@ function validator(value: string) {
 storiesOf('Atoms', module).add('Input', () =>
   Object.entries({
     'To Address': (
-      <Input placeholder="0x4bbeEB066eD09B7AEd07bF39EEe0460DFa261520" />
+      <Input
+        icon="copy"
+        placeholder="0x4bbeEB066eD09B7AEd07bF39EEe0460DFa261520"
+      />
     ),
     Network: <ControlledInput validator={validator} />,
   }).map(([label, element]) => (

--- a/src/atoms/Input/Input.tsx
+++ b/src/atoms/Input/Input.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import { StyledComponentClass } from 'styled-components';
 
-import { Icon, icons } from 'src/atoms';
+import Icon, { icons } from 'src/atoms/Icon';
 import styled from 'src/styled-components';
 import Theme, { borderRadius, scale, transitionDuration } from 'src/Theme';
 import { ExtractProps } from 'src/types';
@@ -20,6 +20,7 @@ const StyledInput = styled(Typography)`
   font-size: ${scale(0)};
   font-weight: bold;
   ${padding(scale(-1), scale(0))};
+  padding-left: 2.8125em;
   transition: border ${transitionDuration}, box-shadow ${transitionDuration};
 
   :focus {
@@ -33,7 +34,8 @@ const StyledInput = styled(Typography)`
 
 const StyledIcon = styled(Icon)`
   position: absolute;
-  left: 0.3125em;
+  left: 0.75em;
+  color: #1eb8e7;
 `;
 
 StyledInput.defaultProps = { as: 'input' };
@@ -58,15 +60,19 @@ export class Input extends Component<
 
   public render() {
     const { icon } = this.props;
+    console.log(StyledIcon);
     if (icon) {
       return (
-        <StyledInput
-          //@ts-ignore
-          ref={this.ref}
-          {...this.props}
-        >
+        <>
+          <StyledInput
+            //@ts-ignore
+            ref={this.ref}
+            {...this.props}
+          >
+            {/* <StyledIcon icon={icon} /> */}
+          </StyledInput>
           <StyledIcon icon={icon} />
-        </StyledInput>
+        </>
       );
     }
     return (

--- a/src/atoms/Input/Input.tsx
+++ b/src/atoms/Input/Input.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import { StyledComponentClass } from 'styled-components';
 
+import { Icon, icons } from 'src/atoms';
 import styled from 'src/styled-components';
 import Theme, { borderRadius, scale, transitionDuration } from 'src/Theme';
 import { ExtractProps } from 'src/types';
@@ -30,11 +31,17 @@ const StyledInput = styled(Typography)`
   Theme
 >;
 
+const StyledIcon = styled(Icon)`
+  position: absolute;
+  left: 0.3125em;
+`;
+
 StyledInput.defaultProps = { as: 'input' };
 
 export class Input extends Component<
   ExtractProps<typeof StyledInput> & {
     value?: string;
+    icon?: keyof typeof icons;
     validator?(value: string): string | undefined;
   }
 > {
@@ -50,6 +57,18 @@ export class Input extends Component<
   }
 
   public render() {
+    const { icon } = this.props;
+    if (icon) {
+      return (
+        <StyledInput
+          //@ts-ignore
+          ref={this.ref}
+          {...this.props}
+        >
+          <StyledIcon icon={icon} />
+        </StyledInput>
+      );
+    }
     return (
       <StyledInput
         //@ts-ignore

--- a/src/atoms/Input/Input.tsx
+++ b/src/atoms/Input/Input.tsx
@@ -13,14 +13,21 @@ import Theme, { borderRadius, scale, transitionDuration } from 'src/Theme';
 import { ExtractProps } from 'src/types';
 import Typography from 'src/Typography';
 
-const StyledInput = styled(Typography)`
+const InputContainer = styled.div`
+  position: relative;
+`;
+
+const StyledInput = styled(Typography)<{ iconSide?: string }>`
   background: ${props => props.theme.controlBackground};
   border: 0.125em solid ${props => props.theme.controlBorder};
   border-radius: ${borderRadius};
   font-size: ${scale(0)};
   font-weight: bold;
   ${padding(scale(-1), scale(0))};
-  padding-left: 2.8125em;
+  ${props =>
+    props.iconSide === 'right'
+      ? 'padding-right: 2.8125em;'
+      : 'padding-left: 2.8125em;'};
   transition: border ${transitionDuration}, box-shadow ${transitionDuration};
 
   :focus {
@@ -32,9 +39,10 @@ const StyledInput = styled(Typography)`
   Theme
 >;
 
-const StyledIcon = styled(Icon)`
+const StyledIcon = styled(Icon)<{ iconSide?: string }>`
   position: absolute;
-  left: 0.75em;
+  top: 0.8em;
+  ${props => (props.iconSide === 'right' ? 'right: 0.75em' : 'left: 0.75em;')};
   color: #1eb8e7;
 `;
 
@@ -44,6 +52,7 @@ export class Input extends Component<
   ExtractProps<typeof StyledInput> & {
     value?: string;
     icon?: keyof typeof icons;
+    iconSide?: string;
     validator?(value: string): string | undefined;
   }
 > {
@@ -59,20 +68,19 @@ export class Input extends Component<
   }
 
   public render() {
-    const { icon } = this.props;
+    const { icon, iconSide } = this.props;
     console.log(StyledIcon);
     if (icon) {
       return (
-        <>
+        <InputContainer>
           <StyledInput
             //@ts-ignore
             ref={this.ref}
+            iconSide={iconSide}
             {...this.props}
-          >
-            {/* <StyledIcon icon={icon} /> */}
-          </StyledInput>
-          <StyledIcon icon={icon} />
-        </>
+          />
+          <StyledIcon icon={icon} iconSide={iconSide} />
+        </InputContainer>
       );
     }
     return (

--- a/src/atoms/Input/Input.tsx
+++ b/src/atoms/Input/Input.tsx
@@ -32,6 +32,7 @@ const StyledInput = styled(Typography)<{ iconSide?: string }>`
   border: none;
   font-size: ${scale(0)};
   font-weight: bold;
+  outline: none;
 ` as StyledComponentClass<
   DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>,
   Theme

--- a/src/atoms/Input/Input.tsx
+++ b/src/atoms/Input/Input.tsx
@@ -14,36 +14,44 @@ import { ExtractProps } from 'src/types';
 import Typography from 'src/Typography';
 
 const InputContainer = styled.div`
-  position: relative;
-`;
-
-const StyledInput = styled(Typography)<{ iconSide?: string }>`
   background: ${props => props.theme.controlBackground};
   border: 0.125em solid ${props => props.theme.controlBorder};
   border-radius: ${borderRadius};
-  font-size: ${scale(0)};
-  font-weight: bold;
-  ${padding(scale(-1), scale(0))};
-  ${props =>
-    props.iconSide === 'right'
-      ? 'padding-right: 2.8125em;'
-      : 'padding-left: 2.8125em;'};
   transition: border ${transitionDuration}, box-shadow ${transitionDuration};
-
-  :focus {
+  ${padding(scale(-1), scale(0))};
+  display: flex;
+  :focus-within {
     outline: none;
     box-shadow: ${props => props.theme.outline};
   }
+`;
+
+const StyledInput = styled(Typography)<{ iconSide?: string }>`
+  flex: 1;
+  background: none;
+  border: none;
+  font-size: ${scale(0)};
+  font-weight: bold;
 ` as StyledComponentClass<
   DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>,
   Theme
 >;
 
 const StyledIcon = styled(Icon)<{ iconSide?: string }>`
-  position: absolute;
-  top: 0.8em;
-  ${props => (props.iconSide === 'right' ? 'right: 0.75em' : 'left: 0.75em;')};
   color: #1eb8e7;
+  margin: auto;
+  ${props =>
+    props.iconSide === 'right'
+      ? 'padding-left: 12px;'
+      : 'padding-right: 12px;'};
+  height: 100%;
+  display: block;
+  /* stylelint-disable max-nesting-depth */
+  span {
+    svg {
+      height: 100;
+    }
+  }
 `;
 
 StyledInput.defaultProps = { as: 'input' };
@@ -69,9 +77,9 @@ export class Input extends Component<
 
   public render() {
     const { icon, iconSide } = this.props;
-    console.log(StyledIcon);
+    const formattedIconSide = iconSide && iconSide.toLowerCase();
     if (icon) {
-      return (
+      return iconSide && formattedIconSide === 'right' ? (
         <InputContainer>
           <StyledInput
             //@ts-ignore
@@ -79,16 +87,29 @@ export class Input extends Component<
             iconSide={iconSide}
             {...this.props}
           />
-          <StyledIcon icon={icon} iconSide={iconSide} />
+          <StyledIcon icon={icon} iconSide={formattedIconSide} />
+        </InputContainer>
+      ) : (
+        <InputContainer>
+          <StyledIcon icon={icon} iconSide={formattedIconSide} />
+          <StyledInput
+            //@ts-ignore
+            ref={this.ref}
+            iconSide={iconSide}
+            {...this.props}
+          />
         </InputContainer>
       );
     }
+
     return (
-      <StyledInput
-        //@ts-ignore
-        ref={this.ref}
-        {...this.props}
-      />
+      <InputContainer>
+        <StyledInput
+          //@ts-ignore
+          ref={this.ref}
+          {...this.props}
+        />
+      </InputContainer>
     );
   }
 }


### PR DESCRIPTION
Add an icon prop to show an icon inside of an input as well as an iconSide prop to choose a side (left or right).

![image](https://user-images.githubusercontent.com/434238/52300185-3b939f00-2955-11e9-840b-cceeb5cf972f.png)
