### PR TITLE
UI-162 Table alignment and padding improvements

### DIFF
--- a/src/molecules/Table/Table.story.tsx
+++ b/src/molecules/Table/Table.story.tsx
@@ -66,6 +66,7 @@ const accountTable: TableData = {
       return aLabel.localeCompare(bLabel);
     },
     hiddenHeadings: ['Favorite'],
+    reversedColumns: ['Value'],
   },
 };
 const recentTransactionsTable: TableData = {
@@ -116,6 +117,7 @@ const recentTransactionsTable: TableData = {
   config: {
     sortableColumn: 'Date',
     hiddenHeadings: ['Image'],
+    reversedColumns: ['Amount'],
   },
 };
 const addressBookTable: TableData = {

--- a/src/molecules/Table/Table.test.tsx
+++ b/src/molecules/Table/Table.test.tsx
@@ -137,6 +137,27 @@ describe('Table', () => {
     });
   });
 
+  test('it reverses columns', () => {
+    const data = generateTableData();
+
+    data.config = {
+      reversedColumns: ['Foo', 'Bar'],
+    };
+
+    data.groups = [
+      {
+        title: 'Bar',
+        entries: [['D', 'E', 'F']],
+      },
+    ];
+
+    const { getByText } = render(<Table {...data} />);
+
+    for (const element of ['Foo', 'Bar']) {
+      expect(getByText(element)).toHaveStyle('text-align: right;');
+    }
+  });
+
   describe('Error handling', () => {
     test('Bad column count', () => {
       const data = generateTableData();

--- a/src/molecules/Table/Table.tsx
+++ b/src/molecules/Table/Table.tsx
@@ -50,9 +50,10 @@ interface State {
   sortedColumnDirection: ColumnDirections;
 }
 
-const sharedCellProperties = `
+const sharedCellProperties = ({ isReversed }: { isReversed?: boolean }) => `
   min-width: 1em;
   padding: 1em;
+  text-align: ${isReversed ? 'right' : 'left'};
 `;
 
 const TableHead = styled.tr`
@@ -70,7 +71,6 @@ interface HeadingProps {
 const TableHeading = styled(Typography)<HeadingProps>`
   ${sharedCellProperties}
   color: ${props => props.theme.headline};
-  text-align: left;
   font-weight: normal;
   text-transform: uppercase;
   letter-spacing: 0.0625em;
@@ -82,7 +82,6 @@ const TableHeading = styled(Typography)<HeadingProps>`
     top: -9999em;
     left: -9999em;
   `}
-  ${props => props.isReversed && 'text-align: right;'}
 ` as StyledComponentClass<
   ClassAttributes<HTMLTableHeaderCellElement> &
     ThHTMLAttributes<HTMLTableHeaderCellElement> &
@@ -116,7 +115,6 @@ const TableCaret = styled(Icon)<{ isFlipped?: boolean }>`
 
 const TableCell = styled(Typography)<{ isReversed?: boolean }>`
   ${sharedCellProperties};
-  ${props => props.isReversed && 'text-align: right;'};
 ` as StyledComponentClass<
   DetailedHTMLProps<
     TdHTMLAttributes<HTMLTableDataCellElement> & { isReversed?: boolean },

--- a/src/molecules/Table/Table.tsx
+++ b/src/molecules/Table/Table.tsx
@@ -22,6 +22,7 @@ export interface TableGroup {
 export interface TableConfig {
   sortableColumn?: string | null;
   hiddenHeadings?: string[];
+  reversedColumns?: string[];
   sortFunction?(a: any, b: any): number;
 }
 
@@ -63,6 +64,7 @@ const TableHead = styled.tr`
 interface HeadingProps {
   isSortable?: boolean;
   isHidden?: boolean;
+  isReversed?: boolean;
 }
 
 const TableHeading = styled(Typography)<HeadingProps>`
@@ -80,6 +82,7 @@ const TableHeading = styled(Typography)<HeadingProps>`
     top: -9999em;
     left: -9999em;
   `}
+  ${props => props.isReversed && 'text-align: right;'}
 ` as StyledComponentClass<
   ClassAttributes<HTMLTableHeaderCellElement> &
     ThHTMLAttributes<HTMLTableHeaderCellElement> &
@@ -111,11 +114,12 @@ const TableCaret = styled(Icon)<{ isFlipped?: boolean }>`
   `};
 `;
 
-const TableCell = styled(Typography)`
+const TableCell = styled(Typography)<{ isReversed?: boolean }>`
   ${sharedCellProperties};
+  ${props => props.isReversed && 'text-align: right;'};
 ` as StyledComponentClass<
   DetailedHTMLProps<
-    TdHTMLAttributes<HTMLTableDataCellElement>,
+    TdHTMLAttributes<HTMLTableDataCellElement> & { isReversed?: boolean },
     HTMLTableDataCellElement
   >,
   Theme
@@ -209,6 +213,10 @@ class AbstractTable extends Component<Props> {
                 config &&
                 config.hiddenHeadings &&
                 config.hiddenHeadings.includes(heading);
+              const isReversedColumn =
+                config &&
+                config.reversedColumns &&
+                config.reversedColumns.includes(heading);
 
               return (
                 <TableHeading
@@ -219,6 +227,7 @@ class AbstractTable extends Component<Props> {
                   role={isSortableColumn ? 'button' : ''}
                   isSortable={isSortableColumn}
                   isHidden={isHiddenHeading}
+                  isReversed={isReversedColumn}
                   data-testid={
                     isSortableColumn ? 'sortable-column-heading' : ''
                   }
@@ -244,6 +253,11 @@ class AbstractTable extends Component<Props> {
               {row.map((cell, cellIndex) => (
                 <TableCell
                   key={cellIndex}
+                  isReversed={
+                    config &&
+                    config.reversedColumns &&
+                    config.reversedColumns.includes(head[cellIndex])
+                  }
                   data-testid={`ungrouped-${rowIndex}-${cellIndex}`}
                 >
                   {cell}
@@ -274,7 +288,16 @@ class AbstractTable extends Component<Props> {
                 entries.map((row, rowIndex) => (
                   <TableRow key={rowIndex}>
                     {row.map((cell, cellIndex) => (
-                      <TableCell key={cellIndex}>{cell}</TableCell>
+                      <TableCell
+                        key={cellIndex}
+                        isReversed={
+                          config &&
+                          config.reversedColumns &&
+                          config.reversedColumns.includes(head[cellIndex])
+                        }
+                      >
+                        {cell}
+                      </TableCell>
                     ))}
                   </TableRow>
                 ))}

--- a/src/molecules/Table/Table.tsx
+++ b/src/molecules/Table/Table.tsx
@@ -52,7 +52,7 @@ interface State {
 
 const sharedCellProperties = `
   min-width: 1em;
-  padding: 1em 1em 1em 0;
+  padding: 1em;
 `;
 
 const TableHead = styled.tr`

--- a/src/molecules/Table/Table.tsx
+++ b/src/molecules/Table/Table.tsx
@@ -203,6 +203,11 @@ class AbstractTable extends Component<Props> {
     const { collapsedGroups, sortedColumnDirection } = this.state;
     const { body, groups } = this.getSortedLayout();
 
+    const isReversedColumn = (heading: string) =>
+      config &&
+      config.reversedColumns &&
+      config.reversedColumns.includes(heading);
+
     return (
       <table {...rest}>
         <thead>
@@ -214,10 +219,6 @@ class AbstractTable extends Component<Props> {
                 config &&
                 config.hiddenHeadings &&
                 config.hiddenHeadings.includes(heading);
-              const isReversedColumn =
-                config &&
-                config.reversedColumns &&
-                config.reversedColumns.includes(heading);
 
               return (
                 <TableHeading
@@ -228,7 +229,7 @@ class AbstractTable extends Component<Props> {
                   role={isSortableColumn ? 'button' : ''}
                   isSortable={isSortableColumn}
                   isHidden={isHiddenHeading}
-                  isReversed={isReversedColumn}
+                  isReversed={isReversedColumn(heading)}
                   data-testid={
                     isSortableColumn ? 'sortable-column-heading' : ''
                   }
@@ -254,11 +255,7 @@ class AbstractTable extends Component<Props> {
               {row.map((cell, cellIndex) => (
                 <TableCell
                   key={cellIndex}
-                  isReversed={
-                    config &&
-                    config.reversedColumns &&
-                    config.reversedColumns.includes(head[cellIndex])
-                  }
+                  isReversed={isReversedColumn(head[cellIndex])}
                   data-testid={`ungrouped-${rowIndex}-${cellIndex}`}
                 >
                   {cell}
@@ -291,11 +288,7 @@ class AbstractTable extends Component<Props> {
                     {row.map((cell, cellIndex) => (
                       <TableCell
                         key={cellIndex}
-                        isReversed={
-                          config &&
-                          config.reversedColumns &&
-                          config.reversedColumns.includes(head[cellIndex])
-                        }
+                        isReversed={isReversedColumn(head[cellIndex])}
                       >
                         {cell}
                       </TableCell>

--- a/src/molecules/Table/Table.tsx
+++ b/src/molecules/Table/Table.tsx
@@ -50,7 +50,11 @@ interface State {
   sortedColumnDirection: ColumnDirections;
 }
 
-const sharedCellProperties = ({ isReversed }: { isReversed?: boolean }) => `
+interface CellProps {
+  isReversed?: boolean;
+}
+
+const sharedCellProperties = ({ isReversed }: CellProps) => `
   min-width: 1em;
   padding: 1em;
   text-align: ${isReversed ? 'right' : 'left'};
@@ -62,10 +66,9 @@ const TableHead = styled.tr`
   background: ${props => props.theme.tableHeadBackground};
 `;
 
-interface HeadingProps {
+interface HeadingProps extends CellProps {
   isSortable?: boolean;
   isHidden?: boolean;
-  isReversed?: boolean;
 }
 
 const TableHeading = styled(Typography)<HeadingProps>`
@@ -113,11 +116,11 @@ const TableCaret = styled(Icon)<{ isFlipped?: boolean }>`
   `};
 `;
 
-const TableCell = styled(Typography)<{ isReversed?: boolean }>`
+const TableCell = styled(Typography)`
   ${sharedCellProperties};
 ` as StyledComponentClass<
   DetailedHTMLProps<
-    TdHTMLAttributes<HTMLTableDataCellElement> & { isReversed?: boolean },
+    TdHTMLAttributes<HTMLTableDataCellElement> & CellProps,
     HTMLTableDataCellElement
   >,
   Theme


### PR DESCRIPTION
## Description
- Column alignment can be reversed in the table config (only supports right alignment for now, in the future we will add RTL support)
- Table cells have left padding for layout consistency

## [JIRA Issue](https://mycrypto.atlassian.net/browse/UI-162)

## [Confluence Component](https://mycrypto.atlassian.net/wiki/spaces/UI/pages/71106664/Table)

## [Zeplin Design](https://app.zeplin.io/project/5b0334f5e91e8c481645ad56/screen/5be46a7a74e6157e788a1f56)
<!-- upload screenshots here -->
![image](https://user-images.githubusercontent.com/927220/52550362-d7823800-2da5-11e9-95c3-b7447af4d784.png)

## [Storybook Story](https://mycryptobuilds.com/ui/ui-162-table-alignment-and-padding-improvements/?selectedKind=Molecules&selectedStory=Table&full=0&addons=1&stories=1&panelRight=0&addonPanel=%40storybook%2Faddon-a11y%2Fpanel)
<!-- upload screenshots here -->
![image](https://user-images.githubusercontent.com/927220/52550311-9558f680-2da5-11e9-835d-abcf6508f594.png)

