### PR TITLE
Select Address Support

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -7,6 +7,7 @@ import React, { StrictMode } from 'react';
 import { withThemesProvider } from 'storybook-addon-styled-component-theme';
 import { configureViewport } from '@storybook/addon-viewport';
 import 'typeface-lato';
+import 'typeface-roboto-mono';
 
 import styled from 'src/styled-components';
 import { dark, light } from 'src/Theme';

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ import { ThemeProvider } from 'styled-components';
 
 ### Typeface
 
-Our designs use the [Lato](http://www.latofonts.com/) typeface, which you will probably need to install in your app or site. There are several options depending on your requirements and build tooling:
+Our designs use the [Lato](http://www.latofonts.com/) and [Roboto Mono](https://fonts.google.com/specimen/Roboto+Mono) typefaces, which you will probably need to install in your app or site. There are several options depending on your requirements and build tooling:
 
-- Use [typeface-lato](https://www.npmjs.com/package/typeface-lato) to self-host your typeface when using npm/yarn with Webpack or any other build tool with CSS and font loaders ([instructions](https://github.com/KyleAMathews/typefaces#how))
-- Use [Google Fonts](https://fonts.google.com/specimen/Lato?selection.family=Lato:400,700,900) to load the font from a CDN (over the Internet) without any configuration (note that [Google collects some usage data](https://developers.google.com/fonts/faq#what_does_using_the_google_fonts_api_mean_for_the_privacy_of_my_users))
-- Download [Lato](http://www.latofonts.com/) directly if you need more control over font loading or if you only plan on using the package locally
+- Use [typeface-lato](https://www.npmjs.com/package/typeface-lato) and [typeface-roboto-mono](https://www.npmjs.com/package/typeface-roboto-mono) to self-host your typefaces when using npm/yarn with Webpack or any other build tool with CSS and font loaders ([instructions](https://github.com/KyleAMathews/typefaces#how))
+- Use [Google Fonts](https://fonts.google.com/?selection.family=Lato:400,700,900|Roboto+Mono) to load the fonts from a CDN (over the Internet) without any configuration (note that [Google collects some usage data](https://developers.google.com/fonts/faq#what_does_using_the_google_fonts_api_mean_for_the_privacy_of_my_users))
+- Download [Lato](http://www.latofonts.com/) and [Roboto Mono](https://fonts.google.com/specimen/Roboto+Mono) directly if you need more control over font loading or if you only plan on using the fonts locally

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mycrypto/ui",
-  "version": "0.15.0",
+  "version": "0.16.0-optional-address-title",
   "description": "The shared UI component library used across all MyCrypto products.",
   "repository": "MyCryptoHQ/ui",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "tslint-config-prettier": "^1.15.0",
     "tslint-react": "^3.6.0",
     "typeface-lato": "^0.0.54",
+    "typeface-roboto-mono": "^0.0.54",
     "typescript": "^3.0.1",
     "typescript-eslint-parser": "^20.0.0",
     "webpack": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mycrypto/ui",
-  "version": "0.14.0",
+  "version": "0.15.0-optional-address-title",
   "description": "The shared UI component library used across all MyCrypto products.",
   "repository": "MyCryptoHQ/ui",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mycrypto/ui",
-  "version": "0.15.0-optional-address-title",
+  "version": "0.15.0-optional-address-title.2",
   "description": "The shared UI component library used across all MyCrypto products.",
   "repository": "MyCryptoHQ/ui",
   "keywords": [

--- a/src/Theme/Theme.story.tsx
+++ b/src/Theme/Theme.story.tsx
@@ -4,7 +4,7 @@ import React, { DetailedHTMLProps, HTMLAttributes } from 'react';
 import { StyledComponentClass, withTheme } from 'styled-components';
 
 import styled from 'src/styled-components';
-import Theme from 'src/Theme';
+import Theme, { monospace } from 'src/Theme';
 import Typography from 'src/Typography';
 
 const Color = styled.div`
@@ -16,7 +16,7 @@ const Color = styled.div`
 `;
 
 const Code = styled(Typography)`
-  font-family: monospace;
+  font-family: ${monospace};
 ` as StyledComponentClass<
   DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>,
   Theme

--- a/src/Theme/Theme.ts
+++ b/src/Theme/Theme.ts
@@ -24,6 +24,8 @@ const textLightnessMod = lightnessMod * 7.5;
 export const scale = (steps: number) => modularScale(steps, undefined, 1.5);
 const switchBackgroundGreyable = lighten(0.3, 'grey');
 export const transitionDuration = '0.12s';
+export const monospace =
+  "'Roboto Mono', Menlo, Monaco, Consolas, 'Courier New', monospace";
 
 export default interface Theme {
   name: string;

--- a/src/Theme/Theme.ts
+++ b/src/Theme/Theme.ts
@@ -18,6 +18,9 @@ const panelBackground = '#282c34';
 const panelBackgroundDark = '#163150';
 const primary = '#007896';
 const primaryDark = '#1eb8e7';
+const text = '#424242';
+const textDark = '#FFFFFF';
+const textLightnessMod = lightnessMod * 7.5;
 export const scale = (steps: number) => modularScale(steps, undefined, 1.5);
 const switchBackgroundGreyable = lighten(0.3, 'grey');
 export const transitionDuration = '0.12s';
@@ -46,6 +49,7 @@ export default interface Theme {
   tableRowBorder: string;
   tableHeadBorder: string;
   text: string;
+  textLight: string;
 }
 
 export const light: Theme = {
@@ -71,7 +75,8 @@ export const light: Theme = {
   tableHeadBorder: '#e8eaed',
   tableRowBorder: '#e8eaed',
   switchBackgroundGreyable,
-  text: '#424242',
+  text,
+  textLight: lighten(textLightnessMod, text),
 };
 
 export const dark: Theme = {
@@ -97,5 +102,6 @@ export const dark: Theme = {
   tableHeadBorder: 'rgba(255, 255, 255, .5)',
   tableRowBorder: panelBackgroundDark,
   switchBackgroundGreyable,
-  text: '#FFFFFF',
+  text: textDark,
+  textLight: darken(textLightnessMod, textDark),
 };

--- a/src/Theme/index.ts
+++ b/src/Theme/index.ts
@@ -3,6 +3,7 @@ import Theme, {
   borderRadiusLarge,
   dark,
   light,
+  monospace,
   scale,
   transitionDuration,
 } from './Theme';
@@ -13,6 +14,7 @@ export {
   borderRadiusLarge,
   dark,
   light,
+  monospace,
   scale,
   transitionDuration,
 };

--- a/src/atoms/Icon/Icon.story.tsx
+++ b/src/atoms/Icon/Icon.story.tsx
@@ -3,13 +3,13 @@ import React, { DetailedHTMLProps, HTMLAttributes } from 'react';
 import { StyledComponentClass } from 'styled-components';
 
 import styled from 'src/styled-components';
-import Theme from 'src/Theme';
+import Theme, { monospace } from 'src/Theme';
 import Typography from 'src/Typography';
 import Icon, { icons } from './Icon';
 
 const Code = styled(Typography)`
   display: block;
-  font-family: monospace;
+  font-family: ${monospace};
 ` as StyledComponentClass<
   DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>,
   Theme

--- a/src/atoms/Identicon/Identicon.tsx
+++ b/src/atoms/Identicon/Identicon.tsx
@@ -1,14 +1,21 @@
 import makeBlockie from 'ethereum-blockies-base64';
-import React, { DetailedHTMLProps, ImgHTMLAttributes } from 'react';
+import React, { ClassAttributes, HTMLAttributes } from 'react';
 import { ThemedOuterStyledProps } from 'styled-components';
 
 import Omit from 'src/Omit';
 import styled from 'src/styled-components';
 import Theme from 'src/Theme';
+import Typography from 'src/Typography';
+
+// We need Typography to set the appropriate em size, but without its extra negative space
+const TypographyWrapper = styled(Typography)`
+  line-height: 0;
+  margin: 0;
+`;
 
 const RoundedImage = styled.img`
   border-radius: 50%;
-  height: 3.75em;
+  height: 2.5em;
 `;
 
 export const Identicon = ({
@@ -16,12 +23,17 @@ export const Identicon = ({
   ...rest
 }: { address: string } & Omit<
   ThemedOuterStyledProps<
-    DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>,
+    ClassAttributes<HTMLParagraphElement> &
+      HTMLAttributes<HTMLParagraphElement> & { muted?: boolean; as?: string },
     Theme
   >,
   'ref'
 >) => {
-  return <RoundedImage src={makeBlockie(address)} {...rest} />;
+  return (
+    <TypographyWrapper {...rest}>
+      <RoundedImage src={makeBlockie(address)} />
+    </TypographyWrapper>
+  );
 };
 
 export default Identicon;

--- a/src/molecules/Copyable/Copyable.tsx
+++ b/src/molecules/Copyable/Copyable.tsx
@@ -23,6 +23,7 @@ const ActiveButton = styled(Icon)`
 
 export class Copyable extends Component<{
   text: string;
+  render?(text: string): ReactNode;
   truncate?(text: string): string;
 }> {
   public state = { copied: false };

--- a/src/molecules/Copyable/Copyable.tsx
+++ b/src/molecules/Copyable/Copyable.tsx
@@ -23,7 +23,6 @@ const ActiveButton = styled(Icon)`
 
 export class Copyable extends Component<{
   text: string;
-  render?(text: string): ReactNode;
   truncate?(text: string): string;
 }> {
   public state = { copied: false };

--- a/src/organisms/Address/Address.story.tsx
+++ b/src/organisms/Address/Address.story.tsx
@@ -31,6 +31,7 @@ class AddressContainer extends Component {
 
 storiesOf('Molecules', module).add('Address', () => (
   <>
+    <Address {...storyProps} title={undefined} />
     <Address {...storyProps} />
     <AddressContainer />
     <Address title={storyProps.title} address="foo.eth" />

--- a/src/organisms/Address/Address.test.tsx
+++ b/src/organisms/Address/Address.test.tsx
@@ -12,8 +12,9 @@ const handleSubmit = jest.fn<(event: FormEvent<HTMLFormElement>) => void>();
 
 test('Copyable', () => {
   const { container, getByText, rerender } = render(
-    <Address address="Address" title="Address" truncate={truncate} />,
+    <Address address="Address" truncate={truncate} />,
   );
+  rerender(<Address address="Address" title="Address" truncate={truncate} />);
   rerender(
     <Address
       address="Address"

--- a/src/organisms/Address/Address.test.tsx
+++ b/src/organisms/Address/Address.test.tsx
@@ -14,6 +14,7 @@ test('Copyable', () => {
   const { container, getByText, rerender } = render(
     <Address address="Address" truncate={truncate} />,
   );
+  getByText('No Label');
   rerender(<Address address="Address" title="Address" truncate={truncate} />);
   rerender(
     <Address

--- a/src/organisms/Address/Address.tsx
+++ b/src/organisms/Address/Address.tsx
@@ -51,10 +51,6 @@ const SubmitButton = styled(ColoredIconButton)`
 
 SubmitButton.defaultProps = { type: 'submit', icon: 'exit' };
 
-const AddressCode = styled.code`
-  font-family: 'Roboto Mono', Menlo, Monaco, Consolas, 'Courier New', monospace;
-`;
-
 interface Props {
   address: string;
   title?: string;
@@ -135,7 +131,7 @@ export class Address extends Component<Props, State> {
               )}
             </>
           )}
-          <Copyable text={address} render={AddressCode} truncate={truncate} />
+          <Copyable text={address} truncate={truncate} />
         </Content>
       </Flex>
     );

--- a/src/organisms/Address/Address.tsx
+++ b/src/organisms/Address/Address.tsx
@@ -3,7 +3,7 @@ import React, { ChangeEvent, Component, FormEvent } from 'react';
 import { Button, Identicon } from 'src/atoms';
 import { Copyable } from 'src/molecules';
 import styled from 'src/styled-components';
-import { borderRadius, scale } from 'src/Theme';
+import { borderRadius, monospace, scale } from 'src/Theme';
 import Typography from 'src/Typography';
 
 const Flex = styled.div`
@@ -11,8 +11,7 @@ const Flex = styled.div`
   display: flex;
 
   * {
-    font-family: 'Roboto Mono', Menlo, Monaco, Consolas, 'Courier New',
-      monospace;
+    font-family: ${monospace};
   }
 `;
 

--- a/src/organisms/Address/Address.tsx
+++ b/src/organisms/Address/Address.tsx
@@ -23,6 +23,13 @@ const Title = styled(Typography)<{ clickable: boolean }>`
 
 Title.defaultProps = { as: 'div' };
 
+const MissingTitle = styled(Title)`
+  color: ${props => props.theme.textLight};
+  font-style: italic;
+`;
+
+MissingTitle.defaultProps = { children: 'No Label' };
+
 const TitleInput = styled.input`
   background: ${props => props.theme.background};
   border: 0.125em solid ${props => props.theme.controlBorder};
@@ -89,6 +96,8 @@ export class Address extends Component<Props, State> {
     const { address, onSubmit, truncate } = this.props;
     const { editing, title } = this.state;
 
+    const TitleComponent = title ? Title : MissingTitle;
+
     return (
       <Flex>
         <Identicon address={address} />
@@ -105,12 +114,12 @@ export class Address extends Component<Props, State> {
             </form>
           ) : (
             <>
-              <Title
+              <TitleComponent
                 onClick={onSubmit && this.handleEditing}
                 clickable={Boolean(onSubmit)}
               >
                 {title}
-              </Title>
+              </TitleComponent>
               {onSubmit && (
                 <>
                   {' '}

--- a/src/organisms/Address/Address.tsx
+++ b/src/organisms/Address/Address.tsx
@@ -9,6 +9,11 @@ import Typography from 'src/Typography';
 const Flex = styled.div`
   align-items: center;
   display: flex;
+
+  * {
+    font-family: 'Roboto Mono', Menlo, Monaco, Consolas, 'Courier New',
+      monospace;
+  }
 `;
 
 const Content = styled.div`

--- a/src/organisms/Address/Address.tsx
+++ b/src/organisms/Address/Address.tsx
@@ -7,6 +7,7 @@ import { borderRadius, scale } from 'src/Theme';
 import Typography from 'src/Typography';
 
 const Flex = styled.div`
+  align-items: center;
   display: flex;
 `;
 
@@ -45,14 +46,14 @@ SubmitButton.defaultProps = { type: 'submit', icon: 'exit' };
 
 interface Props {
   address: string;
-  title: string;
-  onSubmit?(title: string): void;
+  title?: string;
+  onSubmit?(title?: string): void;
   truncate?(text: string): string;
 }
 
 interface State {
   editing: boolean;
-  title: string;
+  title?: string;
 }
 
 export class Address extends Component<Props, State> {

--- a/src/organisms/Address/Address.tsx
+++ b/src/organisms/Address/Address.tsx
@@ -51,6 +51,10 @@ const SubmitButton = styled(ColoredIconButton)`
 
 SubmitButton.defaultProps = { type: 'submit', icon: 'exit' };
 
+const AddressCode = styled.code`
+  font-family: 'Roboto Mono', Menlo, Monaco, Consolas, 'Courier New', monospace;
+`;
+
 interface Props {
   address: string;
   title?: string;
@@ -131,7 +135,7 @@ export class Address extends Component<Props, State> {
               )}
             </>
           )}
-          <Copyable text={address} truncate={truncate} />
+          <Copyable text={address} render={AddressCode} truncate={truncate} />
         </Content>
       </Flex>
     );

--- a/src/organisms/Address/Address.tsx
+++ b/src/organisms/Address/Address.tsx
@@ -53,6 +53,7 @@ SubmitButton.defaultProps = { type: 'submit', icon: 'exit' };
 
 interface Props {
   address: string;
+  className?: string;
   title?: string;
   onSubmit?(title?: string): void;
   truncate?(text: string): string;
@@ -93,13 +94,13 @@ export class Address extends Component<Props, State> {
   };
 
   public render() {
-    const { address, onSubmit, truncate } = this.props;
+    const { address, className, onSubmit, truncate } = this.props;
     const { editing, title } = this.state;
 
     const TitleComponent = title ? Title : MissingTitle;
 
     return (
-      <Flex>
+      <Flex className={className}>
         <Identicon address={address} />
 
         <Content>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10762,6 +10762,11 @@ typeface-lato@^0.0.54:
   version "0.0.54"
   resolved "https://registry.yarnpkg.com/typeface-lato/-/typeface-lato-0.0.54.tgz#6ea56309a8b0cfdb7e8246e05de4b58b8272b47c"
 
+typeface-roboto-mono@^0.0.54:
+  version "0.0.54"
+  resolved "https://registry.yarnpkg.com/typeface-roboto-mono/-/typeface-roboto-mono-0.0.54.tgz#78e706e0a4158b2b670ed3cdf2269e7a54e671cd"
+  integrity sha512-UjE3Y4Bk7DRA3m9aCN4pp8OOGFEYbJH2wK1Qj3Xv2TjEqEJo+oEmQcXwnt1/DKSYAWdKxSL3D/4ida7OoBFkwQ==
+
 typescript-eslint-parser@^20.0.0:
   version "20.0.0"
   resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-20.0.0.tgz#508678796bbcf60365ada28c38bd557e736bec01"


### PR DESCRIPTION
Blocks https://github.com/MyCryptoHQ/MyCrypto/pull/2495 ([CW-29](https://mycrypto.atlassian.net/browse/CW-29))

https://mycryptobuilds.com/ui/optional-address-title/

- [x]  Make Address title optional
  - This allows Addresses to be used with an identicon but without a title/label, such as when selecting unlabelled addresses in a mnemonic/hardware wallet.
  - [Storybook Story](https://mycryptobuilds.com/ui/optional-address-title/?selectedKind=Molecules&selectedStory=Address&full=0&addons=1&stories=1&panelRight=0&addonPanel=%40storybook%2Faddon-a11y%2Fpanel)
![image](https://user-images.githubusercontent.com/927220/56256673-b1c02a80-6097-11e9-87bd-1fc370040c0c.png)
- [x] ~Use monospace font for addresses~ Allow external styling of Address so core can use a monospace font
- [x] Address div should have a align-items: center;
- [x] ~Disable~ Fix responsive typography
- [x] Make identicon 2-2.5 times the height of the font size
- [x] Move monospace style from core to Address