### PR TITLE
Add 'main' to fix Jest compatibility in other projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "MyCrypto",
   "license": "MIT",
   "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "author": "MyCrypto",
   "license": "MIT",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,7 +17,7 @@ const external = [
 export default {
   input: 'src/index.ts',
 
-  output: { file: pkg.module, format: 'es', sourcemap: true },
+  output: { file: pkg.main, format: 'es', sourcemap: true },
 
   // exclude all node modules
   external,


### PR DESCRIPTION
## Description

Jest doesn't support the `module` field in `package.json` currently (facebook/jest#2702). This results in the following error for any projects that use this library and want to test components that include it:

```
Cannot find module '@mycrypto/ui' from 'Component.ts'
```

I renamed the `module` field to `main`, which is the standard for npm packages AFAIK. It shouldn't impact anything else.