### PR TITLE
Tooltip 3box avatar

### DIFF
--- a/src/atoms/Avatar/Avatar.test.tsx
+++ b/src/atoms/Avatar/Avatar.test.tsx
@@ -1,0 +1,12 @@
+import 'jest-dom/extend-expect';
+import React from 'react';
+import { render } from 'react-testing-library';
+
+import Avatar from './Avatar';
+
+test('Panel', () => {
+  const { getByAltText } = render(<Avatar src="/stevebrule.jpg">Panel</Avatar>);
+  const avatar = getByAltText('Avatar');
+
+  expect(avatar.getAttribute('src')).toBe('/stevebrule.jpg');
+});

--- a/src/atoms/Avatar/Avatar.tsx
+++ b/src/atoms/Avatar/Avatar.tsx
@@ -1,0 +1,39 @@
+import React, { ClassAttributes, HTMLAttributes } from 'react';
+import { ThemedOuterStyledProps } from 'styled-components';
+
+import Omit from '../../Omit';
+import styled from '../../styled-components';
+import Theme from '../../Theme';
+import Typography from '../../Typography';
+
+// We need Typography to set the appropriate em size, but without its extra negative space
+const TypographyWrapper = styled(Typography)`
+  line-height: 0;
+  margin: 0;
+`;
+
+const RoundedImage = styled.img`
+  border-radius: 50%;
+  height: 2.5em;
+`;
+
+export const Avatar = ({
+  src,
+  ...rest
+}: { src: string } & Omit<
+  ThemedOuterStyledProps<
+    ClassAttributes<HTMLParagraphElement> &
+      HTMLAttributes<HTMLParagraphElement> & { muted?: boolean; as?: string },
+    Theme
+  >,
+  'ref'
+>) => {
+  console.log('src:', src);
+  return (
+    <TypographyWrapper {...rest}>
+      <RoundedImage src={src} alt="Avatar" />
+    </TypographyWrapper>
+  );
+};
+
+export default Avatar;

--- a/src/atoms/Avatar/index.ts
+++ b/src/atoms/Avatar/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Avatar';

--- a/src/atoms/index.ts
+++ b/src/atoms/index.ts
@@ -1,3 +1,4 @@
+export { default as Avatar } from './Avatar';
 export { default as Button } from './Button';
 export { default as Heading } from './Heading';
 export { default as Icon, icons } from './Icon';

--- a/src/organisms/Address/Address.story.tsx
+++ b/src/organisms/Address/Address.story.tsx
@@ -15,6 +15,14 @@ const storyProps = {
   },
 };
 
+const withAvatarProps = {
+  ...storyProps,
+  tooltip: {
+    image: 'https://www.w3schools.com/howto/img_avatar.png',
+    content: 'Steve Brule',
+  },
+};
+
 class AddressContainer extends Component<
   {},
   {
@@ -33,14 +41,6 @@ class AddressContainer extends Component<
     );
   }
 }
-
-const withAvatarProps = {
-  ...storyProps,
-  tooltip: {
-    image: 'https://www.w3schools.com/howto/img_avatar.png',
-    content: 'Steve Brule',
-  },
-};
 
 storiesOf('Organisms', module).add('Address', () => (
   <>

--- a/src/organisms/Address/Address.story.tsx
+++ b/src/organisms/Address/Address.story.tsx
@@ -34,12 +34,21 @@ class AddressContainer extends Component<
   }
 }
 
-storiesOf('Molecules', module).add('Address', () => (
+const withAvatarProps = {
+  ...storyProps,
+  tooltip: {
+    image: 'https://www.w3schools.com/howto/img_avatar.png',
+    content: 'Steve Brule',
+  },
+};
+
+storiesOf('Organisms', module).add('Address', () => (
   <>
     <Address {...storyProps} title={undefined} />
     <Address {...storyProps} />
     <Address {...storyProps} isCopyable={false} />
     <AddressContainer />
     <Address title={storyProps.title} address="foo.eth" />
+    <Address {...withAvatarProps} />
   </>
 ));

--- a/src/organisms/Address/Address.tsx
+++ b/src/organisms/Address/Address.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, Component, FormEvent } from 'react';
+import React, { ChangeEvent, Component, FormEvent, ReactNode } from 'react';
 
 import { Button, Identicon } from '../../atoms';
 import { Copyable } from '../../molecules';
@@ -55,11 +55,22 @@ const SubmitButton = styled(ColoredIconButton)`
 
 SubmitButton.defaultProps = { type: 'submit', icon: 'exit' };
 
+const RoundedImage = styled.img`
+  border-radius: 50%;
+  height: 2.5em;
+`;
+
+interface Tooltip {
+  image?: string;
+  content: ReactNode | string;
+}
+
 interface Props {
   address: string;
   className?: string;
   title?: string;
   isCopyable?: boolean;
+  tooltip?: Tooltip;
   onSubmit?(title?: string): void;
   truncate?(text: string): string;
 }
@@ -70,6 +81,10 @@ interface State {
 }
 
 export class Address extends Component<Props, State> {
+  public static defaultProps = {
+    isCopyable: true,
+  };
+
   public constructor(props: Props) {
     super(props);
     this.state = { editing: false, title: props.title };
@@ -98,19 +113,28 @@ export class Address extends Component<Props, State> {
     onSubmit!(title);
   };
 
-  public static defaultProps = {
-    isCopyable: true,
-  };
-
   public render() {
-    const { address, className, isCopyable, onSubmit, truncate } = this.props;
+    const {
+      address,
+      className,
+      isCopyable,
+      onSubmit,
+      truncate,
+      tooltip,
+    } = this.props;
     const { editing, title } = this.state;
 
     const TitleComponent = title ? Title : MissingTitle;
+    const ImageComponent = () =>
+      tooltip && tooltip.image ? (
+        <RoundedImage src={tooltip.image} />
+      ) : (
+        <Identicon address={address} />
+      );
 
     return (
       <Flex className={className}>
-        <Identicon address={address} />
+        <ImageComponent />
 
         <Content>
           {editing ? (

--- a/src/organisms/Address/Address.tsx
+++ b/src/organisms/Address/Address.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent, Component, FormEvent, ReactNode } from 'react';
 
-import { Button, Identicon } from '../../atoms';
+import { Avatar, Button, Identicon, Tooltip } from '../../atoms';
 import { Copyable } from '../../molecules';
 import styled from '../../styled-components';
 import { borderRadius, monospace, scale } from '../../Theme';
@@ -55,12 +55,7 @@ const SubmitButton = styled(ColoredIconButton)`
 
 SubmitButton.defaultProps = { type: 'submit', icon: 'exit' };
 
-const RoundedImage = styled.img`
-  border-radius: 50%;
-  height: 2.5em;
-`;
-
-interface Tooltip {
+interface TooltipType {
   image?: string;
   content: ReactNode | string;
 }
@@ -70,7 +65,7 @@ interface Props {
   className?: string;
   title?: string;
   isCopyable?: boolean;
-  tooltip?: Tooltip;
+  tooltip?: TooltipType;
   onSubmit?(title?: string): void;
   truncate?(text: string): string;
 }
@@ -127,15 +122,14 @@ export class Address extends Component<Props, State> {
     const TitleComponent = title ? Title : MissingTitle;
     const ImageComponent = () =>
       tooltip && tooltip.image ? (
-        <RoundedImage src={tooltip.image} />
+        <Avatar src={tooltip.image} />
       ) : (
         <Identicon address={address} />
       );
 
-    return (
+    const addressContent = (
       <Flex className={className}>
         <ImageComponent />
-
         <Content>
           {editing ? (
             <form onSubmit={this.handleSubmit}>
@@ -172,6 +166,14 @@ export class Address extends Component<Props, State> {
           />
         </Content>
       </Flex>
+    );
+
+    return tooltip ? (
+      <Tooltip tooltip={<Typography as="div">{tooltip.content}</Typography>}>
+        {addressContent}
+      </Tooltip>
+    ) : (
+      <>{addressContent}</>
     );
   }
 }


### PR DESCRIPTION
<!-- Please use Clubhouse's "Open PR" button from the relevant story or include links to relevant Clubhouse stories in your branch name, commit messages, or pull request comments. Do not add links to your pull request description, they will be ignored. https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration -->

## Description
This is the first step of integrating the 3Box API. From the spec: "Specifically, we would like for a tooltip profile containing the user’s 3Box profile info to display when hovering over an Identicon in the address book.... 1. Modify address component in UI library to take an optional tooltip property" 

## [Confluence Component](https://mycrypto.atlassian.net/wiki/spaces/UI/pages/42500097/Components)

## [Zeplin Design](https://app.zeplin.io/project/5b0334f5e91e8c481645ad56)

<!-- Upload screenshots here. -->

## [Storybook Story](https://mycryptobuilds.com/ui/)
I wasn't sure how to handle this. Should we let both tooltips coexist? Or maybe disable `Copyable` (the address tooltip) whenever the tooltip object is present and display the user's address in the new tooltip?
![image](https://user-images.githubusercontent.com/32403632/63365096-c9503e00-c32b-11e9-9a1b-c8eabe29055d.png)

