### PR TITLE
Tooltip 3box avatar

### DIFF
--- a/src/molecules/Copyable/Copyable.tsx
+++ b/src/molecules/Copyable/Copyable.tsx
@@ -25,6 +25,7 @@ export class Copyable extends Component<
   {
     text: string;
     isCopyable?: boolean;
+    disableTooltip?: boolean;
     truncate?(text: string): string;
   },
   {
@@ -41,14 +42,15 @@ export class Copyable extends Component<
   };
 
   public render() {
-    const { text, truncate } = this.props;
+    const { text, truncate, disableTooltip } = this.props;
+    const renderedText = truncate ? truncate(text) : text;
 
-    return truncate ? (
+    return truncate && !disableTooltip ? (
       <Tooltip tooltip={<Typography as="div">{text}</Typography>}>
-        {this.renderButton(truncate(text), this.props)}
+        {this.renderButton(renderedText, this.props)}
       </Tooltip>
     ) : (
-      <div>{this.renderButton(text)}</div>
+      <div>{this.renderButton(renderedText)}</div>
     );
   }
 

--- a/src/organisms/Address/Address.story.tsx
+++ b/src/organisms/Address/Address.story.tsx
@@ -19,7 +19,12 @@ const withAvatarProps = {
   ...storyProps,
   tooltip: {
     image: 'https://www.w3schools.com/howto/img_avatar.png',
-    content: 'Steve Brule',
+    content: (
+      <div>
+        <div>{storyProps.title}</div>
+        <div>{storyProps.address}</div>
+      </div>
+    ),
   },
 };
 

--- a/src/organisms/Address/Address.tsx
+++ b/src/organisms/Address/Address.tsx
@@ -127,7 +127,7 @@ export class Address extends Component<Props, State> {
         <Identicon address={address} />
       );
 
-    const addressContent = (
+    const renderAddressContent = (disableCopyableTooltip?: boolean) => (
       <Flex className={className}>
         <ImageComponent />
         <Content>
@@ -163,6 +163,7 @@ export class Address extends Component<Props, State> {
             text={address}
             truncate={truncate}
             isCopyable={isCopyable}
+            disableTooltip={disableCopyableTooltip}
           />
         </Content>
       </Flex>
@@ -170,10 +171,10 @@ export class Address extends Component<Props, State> {
 
     return tooltip ? (
       <Tooltip tooltip={<Typography as="div">{tooltip.content}</Typography>}>
-        {addressContent}
+        {renderAddressContent(true)}
       </Tooltip>
     ) : (
-      <>{addressContent}</>
+      renderAddressContent()
     );
   }
 }


### PR DESCRIPTION
<!-- Please use Clubhouse's "Open PR" button from the relevant story or include links to relevant Clubhouse stories in your branch name, commit messages, or pull request comments. Do not add links to your pull request description, they will be ignored. https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration -->

## Description
Adds a `disableTooltip` prop to Copyable to use when 3box tooltip is present (ie: so we don't have overlapping tooltips)

## [Confluence Component](https://mycrypto.atlassian.net/wiki/spaces/UI/pages/42500097/Components)

## [Zeplin Design](https://app.zeplin.io/project/5b0334f5e91e8c481645ad56)

<!-- Upload screenshots here. -->

## [Storybook Story](https://mycryptobuilds.com/ui/)

<!-- Upload screenshots here. -->
