### PR TITLE
Update tooltip to stay open on hover over tooltip content

### DIFF
--- a/src/atoms/Tooltip/Tooltip.tsx
+++ b/src/atoms/Tooltip/Tooltip.tsx
@@ -71,7 +71,11 @@ export class Tooltip extends Component<
         </div>
 
         {open && (
-          <Absolute height={height}>
+          <Absolute
+            height={height}
+            onMouseEnter={this.onMouseEnter}
+            onMouseLeave={this.onMouseLeave}
+          >
             <Box>{tooltip}</Box>
             <Triangle />
           </Absolute>


### PR DESCRIPTION
## Description
Previously, the tooltip component would only appear when hovering over its trigger component (`Hover here!`), not when hovering over the content of the tooltip (`Hello world!`). This behaviour made clicking buttons inside the tooltip content impossible. 

This PR adds a new check to see if the mouse is hovering over the tooltip content, and makes sure it doesn't disappear in that case.

## Changes
- Update tooltip to stay open on hover over tooltip content

## Screenshots
### Before
![](https://img.luit.me/GySES1WG.gif)

### After
![](https://img.luit.me/sgFknefY.gif)