### PR TITLE
Enable 'skipLibCheck' option in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "sourceMap": true,
     "strict": true,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "skipLibCheck": true
   },
   "include": ["src"],
   "inlineSources": true,


### PR DESCRIPTION
Fixes TypeScript errors, likely caused by some kind of collision between React and the included default types.