### PR TITLE
Max-height scroll-able table

### DIFF
--- a/src/molecules/Table/Table.story.tsx
+++ b/src/molecules/Table/Table.story.tsx
@@ -15,7 +15,7 @@ const FullWidthRow = styled.div`
 const address = '0x80200997f095da94E404F7E0d581AAb1fFba9f7d';
 const truncate = (text: string): string => text.substr(0, 6);
 const accountTable: TableData = {
-  head: ['Favorite', 'Label', 'Address', 'Network', 'Value'],
+  head: ['', 'Label', 'Address', 'Network', 'Value'],
   body: [
     [
       <Icon key={0} icon="star" />,
@@ -211,7 +211,6 @@ const accountTable: TableData = {
       return aLabel.localeCompare(bLabel);
     },
     reversedColumns: ['Value'],
-    maxHeight: '450px',
   },
 };
 const recentTransactionsTable: TableData = {

--- a/src/molecules/Table/Table.story.tsx
+++ b/src/molecules/Table/Table.story.tsx
@@ -235,7 +235,6 @@ const recentTransactionsTable: TableData = {
           '42.69 OMG',
         ],
       ],
-      offset: 1,
     },
     {
       title: 'Completed',
@@ -255,7 +254,6 @@ const recentTransactionsTable: TableData = {
           '13.37 OMG',
         ],
       ],
-      offset: 1,
     },
   ],
   config: {

--- a/src/molecules/Table/Table.story.tsx
+++ b/src/molecules/Table/Table.story.tsx
@@ -63,6 +63,144 @@ const accountTable: TableData = {
       'Ethereum',
       '$1337.70',
     ],
+    [
+      <Icon key={0} icon="starO" />,
+      <div
+        key={1}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
+        <Identicon
+          address={address}
+          style={{
+            width: '35px',
+            height: '35px',
+            marginRight: '1rem',
+          }}
+        />
+        Spongebob's Life Savings
+      </div>,
+      <Copyable key={2} text={address} truncate={truncate} />,
+      'Ethereum',
+      '$1337.70',
+    ],
+    [
+      <Icon key={0} icon="starO" />,
+      <div
+        key={1}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
+        <Identicon
+          address={address}
+          style={{
+            width: '35px',
+            height: '35px',
+            marginRight: '1rem',
+          }}
+        />
+        Spongebob's Life Savings
+      </div>,
+      <Copyable key={2} text={address} truncate={truncate} />,
+      'Ethereum',
+      '$1337.70',
+    ],
+    [
+      <Icon key={0} icon="starO" />,
+      <div
+        key={1}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
+        <Identicon
+          address={address}
+          style={{
+            width: '35px',
+            height: '35px',
+            marginRight: '1rem',
+          }}
+        />
+        Spongebob's Life Savings
+      </div>,
+      <Copyable key={2} text={address} truncate={truncate} />,
+      'Ethereum',
+      '$1337.70',
+    ],
+    [
+      <Icon key={0} icon="starO" />,
+      <div
+        key={1}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
+        <Identicon
+          address={address}
+          style={{
+            width: '35px',
+            height: '35px',
+            marginRight: '1rem',
+          }}
+        />
+        Spongebob's Life Savings
+      </div>,
+      <Copyable key={2} text={address} truncate={truncate} />,
+      'Ethereum',
+      '$1337.70',
+    ],
+    [
+      <Icon key={0} icon="starO" />,
+      <div
+        key={1}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
+        <Identicon
+          address={address}
+          style={{
+            width: '35px',
+            height: '35px',
+            marginRight: '1rem',
+          }}
+        />
+        Spongebob's Life Savings
+      </div>,
+      <Copyable key={2} text={address} truncate={truncate} />,
+      'Ethereum',
+      '$1337.70',
+    ],
+    [
+      <Icon key={0} icon="starO" />,
+      <div
+        key={1}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
+        <Identicon
+          address={address}
+          style={{
+            width: '35px',
+            height: '35px',
+            marginRight: '1rem',
+          }}
+        />
+        Spongebob's Life Savings
+      </div>,
+      <Copyable key={2} text={address} truncate={truncate} />,
+      'Ethereum',
+      '$1337.70',
+    ],
   ],
   config: {
     sortableColumn: 'Label',
@@ -72,8 +210,8 @@ const accountTable: TableData = {
 
       return aLabel.localeCompare(bLabel);
     },
-    hiddenHeadings: ['Favorite'],
     reversedColumns: ['Value'],
+    maxHeight: '450px',
   },
 };
 const recentTransactionsTable: TableData = {
@@ -123,10 +261,11 @@ const recentTransactionsTable: TableData = {
   ],
   config: {
     sortableColumn: 'Date',
-    hiddenHeadings: ['Image'],
     reversedColumns: ['Amount'],
+    maxHeight: '250px',
   },
 };
+
 const addressBookTable: TableData = {
   head: ['Favorite', 'Label', 'Address', 'Notes', ''],
   overlay: <FullWidthRow>haha</FullWidthRow>,
@@ -162,7 +301,6 @@ const addressBookTable: TableData = {
   ],
   config: {
     sortableColumn: 'Label',
-    hiddenHeadings: ['Favorite'],
   },
 };
 

--- a/src/molecules/Table/Table.test.tsx
+++ b/src/molecules/Table/Table.test.tsx
@@ -47,20 +47,6 @@ describe('Table', () => {
     expect(queryByText('F')).toBeTruthy();
   });
 
-  test('It hides headings', () => {
-    const data = generateTableData();
-
-    data.config = {
-      hiddenHeadings: ['Foo'],
-    };
-
-    const { getByText } = render(<Table {...data} />);
-
-    expect(getByText('Foo')).toHaveStyle(
-      'position: fixed; top: -9999em; left: -9999em;',
-    );
-  });
-
   describe('Column sorting', () => {
     test('It sorts columns using the default sortFunction', () => {
       const data = generateTableData();
@@ -245,18 +231,6 @@ describe('Table', () => {
 
       expect(() => render(<Table {...data} />)).toThrow(
         `Nonexistent sortable column provided to <Table />.`,
-      );
-    });
-
-    test('Unused hidden heading', () => {
-      const data = generateTableData();
-
-      data.config = {
-        hiddenHeadings: ['Hmm'],
-      };
-
-      expect(() => render(<Table {...data} />)).toThrow(
-        `Unused heading Hmm found in hiddenHeadings in <Table />`,
       );
     });
   });

--- a/src/molecules/Table/Table.test.tsx
+++ b/src/molecules/Table/Table.test.tsx
@@ -206,22 +206,6 @@ describe('Table', () => {
       );
     });
 
-    test('Bad group offset', () => {
-      const data = generateTableData();
-
-      data.groups = [
-        {
-          title: 'Derp',
-          entries: [['D', 'E', 'F']],
-          offset: 3,
-        },
-      ];
-
-      expect(() => render(<Table {...data} />)).toThrow(
-        `Bad offset in group "Derp" found in <Table />.`,
-      );
-    });
-
     test('Nonexistent sortable column', () => {
       const data = generateTableData();
 

--- a/src/molecules/Table/Table.tsx
+++ b/src/molecules/Table/Table.tsx
@@ -21,8 +21,8 @@ export interface TableGroup {
 
 export interface TableConfig {
   sortableColumn?: string | null;
-  hiddenHeadings?: string[];
   reversedColumns?: string[];
+  maxHeight?: string;
   sortFunction?(a: any, b: any): number;
 }
 
@@ -63,14 +63,12 @@ const sharedCellProperties = ({ isReversed }: CellProps) => `
 `;
 
 const TableHead = styled.tr`
-  border-top: 0.0625em solid ${props => props.theme.tableHeadBorder};
   border-bottom: 0.0625em solid ${props => props.theme.tableHeadBorder};
   background: ${props => props.theme.tableHeadBackground};
 `;
 
 interface HeadingProps extends CellProps {
   isSortable?: boolean;
-  isHidden?: boolean;
 }
 
 const TableHeading = styled(Typography)<HeadingProps>`
@@ -79,14 +77,11 @@ const TableHeading = styled(Typography)<HeadingProps>`
   font-weight: normal;
   text-transform: uppercase;
   letter-spacing: 0.0625em;
-  cursor: ${props => (props.isSortable ? 'pointer' : 'inherit')}
-    ${props =>
-      props.isHidden &&
-      `
-    position: fixed;
-    top: -9999em;
-    left: -9999em;
-  `}
+  border-top: '0px';
+  position: sticky;
+  top: 0;
+  background: ${props => props.theme.tableHeadBackground};
+  cursor: ${props => (props.isSortable ? 'pointer' : 'inherit')};
 ` as StyledComponentClass<
   ClassAttributes<HTMLTableHeaderCellElement> &
     ThHTMLAttributes<HTMLTableHeaderCellElement> &
@@ -122,6 +117,18 @@ const TableCaret = styled(Icon)<{ isFlipped?: boolean }>`
       transform: rotateX(180deg);
     }
   `};
+`;
+
+const TableContainer = styled('div')<{ maxHeight?: string }>`
+  display: block;
+  overflow: auto;
+  max-height: ${({ maxHeight }) => maxHeight};
+  width: 100%;
+`;
+
+const TableHeaderContainer = styled.thead`
+  & th {
+  }
 `;
 
 const TableCell = styled(Typography)`
@@ -217,54 +224,61 @@ class AbstractTable extends Component<Props, State> {
       config.reversedColumns.includes(heading);
 
     return (
-      <table {...rest}>
-        <thead>
-          <TableHead>
-            {head.map((heading, index) => {
-              const isSortableColumn =
-                config && config.sortableColumn === heading;
-              const isHiddenHeading =
-                config &&
-                config.hiddenHeadings &&
-                config.hiddenHeadings.includes(heading);
+      <TableContainer maxHeight={config && config.maxHeight}>
+        <table {...rest}>
+          <TableHeaderContainer>
+            <TableHead>
+              {head.map((heading, index) => {
+                const isSortableColumn =
+                  config && config.sortableColumn === heading;
 
-              return (
-                <TableHeading
-                  key={index}
-                  onClick={
-                    isSortableColumn ? this.toggleSortedColumnDirection : noop
-                  }
-                  role={isSortableColumn ? 'button' : ''}
-                  isSortable={isSortableColumn}
-                  isHidden={isHiddenHeading}
-                  isReversed={isReversedColumn(heading)}
-                  data-testid={
-                    isSortableColumn ? 'sortable-column-heading' : ''
-                  }
-                >
-                  {heading}
-                  {isSortableColumn && (
-                    <TableCaret
-                      icon="navDownCaret"
-                      isFlipped={
-                        sortedColumnDirection === ColumnDirections.Reverse
-                      }
-                    />
-                  )}
-                </TableHeading>
-              );
-            })}
-          </TableHead>
-        </thead>
-        <tbody>
-          {/* Ungrouped rows are placed on top of grouped rows. */}
-          {body.map((row, rowIndex) => (
-            <TableRow key={rowIndex}>
-              {overlay ? (
-                overlayRows ? (
-                  // Render overlay component for any row in the overlay list
-                  overlayRows.includes(rowIndex) ? (
-                    <td colSpan={head.length}>{overlay}</td>
+                return (
+                  <TableHeading
+                    key={index}
+                    onClick={
+                      isSortableColumn ? this.toggleSortedColumnDirection : noop
+                    }
+                    role={isSortableColumn ? 'button' : ''}
+                    isSortable={isSortableColumn}
+                    isReversed={isReversedColumn(heading)}
+                    data-testid={
+                      isSortableColumn ? 'sortable-column-heading' : ''
+                    }
+                  >
+                    {heading}
+                    {isSortableColumn && (
+                      <TableCaret
+                        icon="navDownCaret"
+                        isFlipped={
+                          sortedColumnDirection === ColumnDirections.Reverse
+                        }
+                      />
+                    )}
+                  </TableHeading>
+                );
+              })}
+            </TableHead>
+          </TableHeaderContainer>
+          <tbody>
+            {/* Ungrouped rows are placed on top of grouped rows. */}
+            {body.map((row, rowIndex) => (
+              <TableRow key={rowIndex}>
+                {overlay ? (
+                  overlayRows ? (
+                    // Render overlay component for any row in the overlay list
+                    overlayRows.includes(rowIndex) ? (
+                      <td colSpan={head.length}>{overlay}</td>
+                    ) : (
+                      row.map((cell, cellIndex) => (
+                        <TableCell
+                          key={cellIndex}
+                          isReversed={isReversedColumn(head[cellIndex])}
+                          data-testid={`ungrouped-${rowIndex}-${cellIndex}`}
+                        >
+                          {cell}
+                        </TableCell>
+                      ))
+                    )
                   ) : (
                     row.map((cell, cellIndex) => (
                       <TableCell
@@ -286,56 +300,46 @@ class AbstractTable extends Component<Props, State> {
                       {cell}
                     </TableCell>
                   ))
-                )
-              ) : (
-                row.map((cell, cellIndex) => (
-                  <TableCell
-                    key={cellIndex}
-                    isReversed={isReversedColumn(head[cellIndex])}
-                    data-testid={`ungrouped-${rowIndex}-${cellIndex}`}
-                  >
-                    {cell}
-                  </TableCell>
-                ))
-              )}
-            </TableRow>
-          ))}
-          {groups!.map(({ title, entries, offset = 0 }) => (
-            <React.Fragment key={title}>
-              <TableGroupHead
-                onClick={this.toggleCollapseGroup.bind(this, title)}
-                role="button"
-              >
-                {/* Enter ghost cells to facilitate the offset. */}
-                {Array.from({ length: offset }, (_, index) => (
-                  <td key={index} />
-                ))}
-                <TableHeading colSpan={head.length - offset}>
-                  {title}
-                  <TableCaret
-                    icon="navDownCaret"
-                    isFlipped={collapsedGroups[title]}
-                  />
-                </TableHeading>
-              </TableGroupHead>
-              {/* Display group rows if not collapsed. */}
-              {!collapsedGroups[title] &&
-                entries.map((row, rowIndex) => (
-                  <TableRow key={rowIndex}>
-                    {row.map((cell, cellIndex) => (
-                      <TableCell
-                        key={cellIndex}
-                        isReversed={isReversedColumn(head[cellIndex])}
-                      >
-                        {cell}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                ))}
-            </React.Fragment>
-          ))}
-        </tbody>
-      </table>
+                )}
+              </TableRow>
+            ))}
+            {groups!.map(({ title, entries, offset = 0 }) => (
+              <React.Fragment key={title}>
+                <TableGroupHead
+                  onClick={this.toggleCollapseGroup.bind(this, title)}
+                  role="button"
+                >
+                  {/* Enter ghost cells to facilitate the offset. */}
+                  {Array.from({ length: offset }, (_, index) => (
+                    <td key={index} />
+                  ))}
+                  <TableHeading colSpan={head.length - offset}>
+                    {title}
+                    <TableCaret
+                      icon="navDownCaret"
+                      isFlipped={collapsedGroups[title]}
+                    />
+                  </TableHeading>
+                </TableGroupHead>
+                {/* Display group rows if not collapsed. */}
+                {!collapsedGroups[title] &&
+                  entries.map((row, rowIndex) => (
+                    <TableRow key={rowIndex}>
+                      {row.map((cell, cellIndex) => (
+                        <TableCell
+                          key={cellIndex}
+                          isReversed={isReversedColumn(head[cellIndex])}
+                        >
+                          {cell}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+              </React.Fragment>
+            ))}
+          </tbody>
+        </table>
+      </TableContainer>
     );
   }
 
@@ -391,7 +395,7 @@ class AbstractTable extends Component<Props, State> {
       }
     });
 
-    const { sortableColumn, hiddenHeadings } = config!;
+    const { sortableColumn } = config!;
 
     if (sortableColumn) {
       const sortedColumnExists = head.includes(sortableColumn);
@@ -399,16 +403,6 @@ class AbstractTable extends Component<Props, State> {
       if (!sortedColumnExists) {
         throw new Error(`Nonexistent sortable column provided to <Table />.`);
       }
-    }
-
-    if (hiddenHeadings) {
-      hiddenHeadings.forEach(heading => {
-        if (!head.includes(heading)) {
-          throw new Error(
-            `Unused heading ${heading} found in hiddenHeadings in <Table />`,
-          );
-        }
-      });
     }
   };
 

--- a/src/molecules/Table/Table.tsx
+++ b/src/molecules/Table/Table.tsx
@@ -16,7 +16,6 @@ import Typography from '../../Typography';
 export interface TableGroup {
   title: string;
   entries: ReactNode[][];
-  offset?: number;
 }
 
 export interface TableConfig {
@@ -301,17 +300,13 @@ class AbstractTable extends Component<Props, State> {
                 )}
               </TableRow>
             ))}
-            {groups!.map(({ title, entries, offset = 0 }) => (
+            {groups!.map(({ title, entries }) => (
               <React.Fragment key={title}>
                 <TableGroupHead
                   onClick={this.toggleCollapseGroup.bind(this, title)}
                   role="button"
                 >
-                  {/* Enter ghost cells to facilitate the offset. */}
-                  {Array.from({ length: offset }, (_, index) => (
-                    <td key={index} />
-                  ))}
-                  <TableHeading colSpan={head.length - offset}>
+                  <TableHeading colSpan={head.length}>
                     {title}
                     <TableCaret
                       icon="navDownCaret"
@@ -373,7 +368,7 @@ class AbstractTable extends Component<Props, State> {
       }
     });
 
-    groups!.forEach(({ title, entries, offset }) => {
+    groups!.forEach(({ title, entries }) => {
       if (!title || title === '') {
         throw new Error(
           `Untitled group in <Table /> -- all table groups must have a title.`,
@@ -387,10 +382,6 @@ class AbstractTable extends Component<Props, State> {
           );
         }
       });
-
-      if (offset && offset > columnCount - 1) {
-        throw new Error(`Bad offset in group "${title}" found in <Table />.`);
-      }
     });
 
     const { sortableColumn } = config!;

--- a/src/molecules/Table/Table.tsx
+++ b/src/molecules/Table/Table.tsx
@@ -120,10 +120,8 @@ const TableCaret = styled(Icon)<{ isFlipped?: boolean }>`
 `;
 
 const TableContainer = styled('div')<{ maxHeight?: string }>`
-  display: block;
   overflow: auto;
   max-height: ${({ maxHeight }) => maxHeight};
-  width: 100%;
 `;
 
 const TableHeaderContainer = styled.thead`

--- a/src/organisms/CollapsibleTable/CollapsibleTable.story.tsx
+++ b/src/organisms/CollapsibleTable/CollapsibleTable.story.tsx
@@ -38,7 +38,6 @@ const iconData: CollapsibleTableData = {
   config: {
     primaryColumn: 'Name',
     iconColumns: ['Favorite', 'Watching'],
-    hiddenHeadings: ['Favorite', 'Watching'],
   },
 };
 


### PR DESCRIPTION
# Description
Creates a max-height param for table body that allows for scroll-able body and sticky header.

I had to remove "hiddenHeader" param because the sticky positioning runs perpendicular to it. I don't think we're using hidden headers in beta anyways, since we're just using empty strings in headers.