### PR TITLE
Fix font loading in Storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,11 @@
 import { ThemeProvider } from 'styled-components';
 import { theme } from '../src';
 
+import '@fontsource/lato/300.css';
+import '@fontsource/lato/400.css';
+import '@fontsource/lato/700.css';
+import '@fontsource/roboto-mono/400.css';
+
 export const decorators = [
   (Story) => (
     <ThemeProvider theme={theme}>

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import { ThemeProvider } from 'styled-components';
 
 Our designs use the [Lato](http://www.latofonts.com/) and [Roboto Mono](https://fonts.google.com/specimen/Roboto+Mono) typefaces, which you will probably need to install in your app or site. There are several options depending on your requirements and build tooling:
 
-- Use [@fontsource/lato](https://www.npmjs.com/package/@fontsource/lato) and [@fontsource/roboto-mono](https://www.npmjs.com/package/@fontsource/roboto-mono) to self-host your typefaces when using npm/yarn with Webpack or any other build tool with CSS and font loaders ([instructions](https://github.com/KyleAMathews/typefaces#how))
+- Use [@fontsource/lato](https://www.npmjs.com/package/@fontsource/lato) and [@fontsource/roboto-mono](https://www.npmjs.com/package/@fontsource/roboto-mono) to self-host your typefaces when using npm/yarn with Webpack or any other build tool with CSS and font loaders ([instructions](https://github.com/fontsource/fontsource#installation))
 - Use [Google Fonts](https://fonts.google.com/?selection.family=Lato:400,700,900|Roboto+Mono) to load the fonts from a CDN (over the Internet) without any configuration (note that [Google collects some usage data](https://developers.google.com/fonts/faq#what_does_using_the_google_fonts_api_mean_for_the_privacy_of_my_users))
 - Download [Lato](http://www.latofonts.com/) and [Roboto Mono](https://fonts.google.com/specimen/Roboto+Mono) directly if you need more control over font loading or if you only plan on using the fonts locally
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import { ThemeProvider } from 'styled-components';
 
 Our designs use the [Lato](http://www.latofonts.com/) and [Roboto Mono](https://fonts.google.com/specimen/Roboto+Mono) typefaces, which you will probably need to install in your app or site. There are several options depending on your requirements and build tooling:
 
-- Use [typeface-lato](https://www.npmjs.com/package/typeface-lato) and [typeface-roboto-mono](https://www.npmjs.com/package/typeface-roboto-mono) to self-host your typefaces when using npm/yarn with Webpack or any other build tool with CSS and font loaders ([instructions](https://github.com/KyleAMathews/typefaces#how))
+- Use [@fontsource/lato](https://www.npmjs.com/package/@fontsource/lato) and [@fontsource/roboto-mono](https://www.npmjs.com/package/@fontsource/roboto-mono) to self-host your typefaces when using npm/yarn with Webpack or any other build tool with CSS and font loaders ([instructions](https://github.com/KyleAMathews/typefaces#how))
 - Use [Google Fonts](https://fonts.google.com/?selection.family=Lato:400,700,900|Roboto+Mono) to load the fonts from a CDN (over the Internet) without any configuration (note that [Google collects some usage data](https://developers.google.com/fonts/faq#what_does_using_the_google_fonts_api_mean_for_the_privacy_of_my_users))
 - Download [Lato](http://www.latofonts.com/) and [Roboto Mono](https://fonts.google.com/specimen/Roboto+Mono) directly if you need more control over font loading or if you only plan on using the fonts locally
 

--- a/package.json
+++ b/package.json
@@ -33,16 +33,15 @@
     "format": "prettier --write --ignore-path .gitignore '**/*.{ts,tsx,js,json,yml}'",
     "prepare": "simple-git-hooks"
   },
-  "dependencies": {
-    "@fontsource/lato": "^4.2.2",
-    "@fontsource/roboto-mono": "^4.2.2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/cli": "^7.13.14",
     "@babel/core": "^7.13.14",
     "@babel/preset-env": "^7.13.12",
     "@babel/preset-react": "^7.13.13",
     "@babel/preset-typescript": "^7.13.0",
+    "@fontsource/lato": "^4.2.2",
+    "@fontsource/roboto-mono": "^4.2.2",
     "@storybook/addon-essentials": "^6.2.3",
     "@storybook/addons": "^6.2.3",
     "@storybook/builder-webpack5": "^6.2.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,2 @@
-import '@fontsource/lato';
-import '@fontsource/roboto-mono';
-
 export * from './atoms';
 export * from './theme';


### PR DESCRIPTION
Projects using `@mycrypto/ui` are responsible for loading fonts, as described in `README.md`. This PR makes the font dependencies dev-only and fixes font loading in Storybook.